### PR TITLE
feat: Add option for organisers to select submission type

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -138,7 +138,7 @@ def create_app():
 
     # Initialize database with the app
     db.init_app(flask_app)
-
+    
     # Initialize JWT manager for token handling
     JWTManager(flask_app)
 
@@ -176,7 +176,6 @@ app = create_app()
 app.register_blueprint(user_bp, url_prefix='/api/user')  # User management endpoints
 app.register_blueprint(contest_bp, url_prefix='/api/contest')  # Contest endpoints
 app.register_blueprint(submission_bp, url_prefix='/api/submission')  # Submission endpoints
-
 # =============================================================================
 # AUTHENTICATION ENDPOINTS
 # =============================================================================

--- a/backend/models/contest.py
+++ b/backend/models/contest.py
@@ -51,6 +51,7 @@ class Contest(BaseModel):
     rules = db.Column(db.Text, nullable=True)  # JSON string
     marks_setting_accepted = db.Column(db.Integer, default=0, nullable=False)
     marks_setting_rejected = db.Column(db.Integer, default=0, nullable=False)
+    allowed_submission_type = db.Column(db.String(20), default="both", nullable=False)
 
     # Jury members (comma-separated usernames)
     jury_members = db.Column(db.Text, nullable=True)
@@ -82,6 +83,8 @@ class Contest(BaseModel):
         self.end_date = kwargs.get('end_date')
         self.marks_setting_accepted = kwargs.get('marks_setting_accepted', 0)
         self.marks_setting_rejected = kwargs.get('marks_setting_rejected', 0)
+        self.allowed_submission_type = kwargs.get('allowed_submission_type', 'both')
+
 
         # Handle rules and jury_members
         self.set_rules(kwargs.get('rules', {}))
@@ -249,12 +252,13 @@ class Contest(BaseModel):
             'rules': self.get_rules(),
             'marks_setting_accepted': self.marks_setting_accepted,
             'marks_setting_rejected': self.marks_setting_rejected,
+            'allowed_submission_type': self.allowed_submission_type,
             'jury_members': self.get_jury_members(),
             # Format datetime as ISO string with 'Z' suffix to indicate UTC
             # This ensures JavaScript interprets it as UTC, not local time
             'created_at': (self.created_at.isoformat() + 'Z') if self.created_at else None,
             'submission_count': self.get_submission_count(),
-            'status': self.get_status()
+            'status': self.get_status()      
         }
 
     def __repr__(self):

--- a/backend/routes/contest_routes.py
+++ b/backend/routes/contest_routes.py
@@ -155,6 +155,7 @@ def create_contest():
     # Parse scoring settings
     marks_accepted = data.get('marks_setting_accepted', 0)
     marks_rejected = data.get('marks_setting_rejected', 0)
+    allowed_submission_type = data.get("allowed_submission_type", "both")
 
     try:
         marks_accepted = int(marks_accepted)
@@ -175,7 +176,8 @@ def create_contest():
             rules=rules,
             marks_setting_accepted=marks_accepted,
             marks_setting_rejected=marks_rejected,
-            jury_members=jury_members
+            jury_members=jury_members,
+            allowed_submission_type=allowed_submission_type  
         )
 
         contest.save()
@@ -365,7 +367,16 @@ def update_contest(contest_id):  # pylint: disable=too-many-return-statements
                 contest.set_rules(rules_payload)
             else:
                 contest.set_rules({'text': ''})
+        
+        if "allowed_submission_type" in data:
+           new_type = data.get("allowed_submission_type", "both")
 
+          # Validate only allowed values
+        if new_type not in ["new", "expansion", "both"]:
+                return jsonify({"error": "Invalid allowed_submission_type"}), 400
+
+        contest.allowed_submission_type = new_type
+    
         # --- Dates ---
         if 'start_date' in data:
             parsed = parse_date_or_none(data.get('start_date'))

--- a/docs/PROJECT_DOCUMENTATION.md
+++ b/docs/PROJECT_DOCUMENTATION.md
@@ -98,6 +98,8 @@ class Contest(db.Model):
     end_date = db.Column(db.DateTime, nullable=False)
     created_by = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    allowed_submission_type = db.Column(db.String(20), default="both")
+
 ```
 
 **Purpose**: Manages contest information, timing, and creator relationships.

--- a/frontend/src/components/CreateContestModal.vue
+++ b/frontend/src/components/CreateContestModal.vue
@@ -11,68 +11,41 @@
             <div class="row">
               <div class="col-md-6 mb-3">
                 <label for="contestName" class="form-label">Contest Name *</label>
-                <input
-                  type="text"
-                  class="form-control"
-                  id="contestName"
-                  v-model="formData.name"
-                  required
-                />
+                <input type="text" class="form-control" id="contestName" v-model="formData.name" required />
               </div>
               <div class="col-md-6 mb-3">
                 <label for="projectName" class="form-label">Project Name *</label>
-                <input
-                  type="text"
-                  class="form-control"
-                  id="projectName"
-                  v-model="formData.project_name"
-                  required
-                />
+                <input type="text" class="form-control" id="projectName" v-model="formData.project_name" required />
               </div>
             </div>
 
             <div class="mb-3">
               <label for="contestDescription" class="form-label">Description</label>
-              <textarea
-                class="form-control"
-                id="contestDescription"
-                rows="3"
-                v-model="formData.description"
-              ></textarea>
+              <textarea class="form-control" id="contestDescription" rows="3" v-model="formData.description"></textarea>
             </div>
             <div class="mb-3">
-  <label for="contestRules" class="form-label">Contest Rules *</label>
-  <textarea
-    class="form-control"
-    id="contestRules"
-    rows="4"
-    placeholder="Write rules about how articles must be submitted."
-    v-model="formData.rules_text"
-    required
-  ></textarea>
-</div>
-
+              <label for="contestRules" class="form-label">Contest Rules *</label>
+              <textarea class="form-control" id="contestRules" rows="4"
+                placeholder="Write rules about how articles must be submitted." v-model="formData.rules_text"
+                required></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="allowedType" class="form-label">Allowed Submission Type</label>
+              <select id="allowedType" class="form-control" v-model="formData.allowed_submission_type">
+                <option value="new">New Article Only</option>
+                <option value="expansion">Improved Article Only</option>
+                <option value="both">Both(New Article + Improved Article)</option>
+              </select>
+            </div>
 
             <div class="row">
               <div class="col-md-6 mb-3">
                 <label for="startDate" class="form-label">Start Date *</label>
-                <input
-                  type="date"
-                  class="form-control"
-                  id="startDate"
-                  v-model="formData.start_date"
-                  required
-                />
+                <input type="date" class="form-control" id="startDate" v-model="formData.start_date" required />
               </div>
               <div class="col-md-6 mb-3">
                 <label for="endDate" class="form-label">End Date *</label>
-                <input
-                  type="date"
-                  class="form-control"
-                  id="endDate"
-                  v-model="formData.end_date"
-                  required
-                />
+                <input type="date" class="form-control" id="endDate" v-model="formData.end_date" required />
               </div>
             </div>
 
@@ -88,12 +61,8 @@
                 <small v-if="selectedJury.length === 0" class="jury-placeholder-text">
                   No jury members selected yet
                 </small>
-                <span
-                  v-for="username in selectedJury"
-                  :key="username"
-                  class="badge bg-primary me-2 mb-2"
-                  style="font-size: 0.9rem; cursor: pointer;"
-                >
+                <span v-for="username in selectedJury" :key="username" class="badge bg-primary me-2 mb-2"
+                  style="font-size: 0.9rem; cursor: pointer;">
                   {{ username }}
                   <i class="fas fa-times ms-1" @click="removeJury(username)"></i>
                 </span>
@@ -101,33 +70,19 @@
 
               <!-- Jury Input with Autocomplete -->
               <div style="position: relative;">
-                <input
-                  type="text"
-                  class="form-control"
-                  id="juryInput"
-                  v-model="jurySearchQuery"
-                  @input="searchJury"
-                  placeholder="Type username to search..."
-                  autocomplete="off"
-                />
+                <input type="text" class="form-control" id="juryInput" v-model="jurySearchQuery" @input="searchJury"
+                  placeholder="Type username to search..." autocomplete="off" />
                 <!-- Autocomplete Dropdown -->
                 <!--
                   Note: we avoid hard-coded light backgrounds here so that
                   the dropdown looks correct in both light and dark modes.
                   Colors now come from CSS variables defined in the styles below.
                 -->
-                <div
-                  v-if="jurySearchResults.length > 0 && jurySearchQuery.length >= 2"
+                <div v-if="jurySearchResults.length > 0 && jurySearchQuery.length >= 2"
                   class="jury-autocomplete position-absolute w-100 border rounded-bottom"
-                  style="max-height: 200px; overflow-y: auto; z-index: 1000; box-shadow: 0 2px 8px rgba(0,0,0,0.1);"
-                >
-                  <div
-                    v-for="user in jurySearchResults"
-                    :key="user.username"
-                    class="p-2 border-bottom cursor-pointer"
-                    style="cursor: pointer;"
-                    @click="addJury(user.username)"
-                  >
+                  style="max-height: 200px; overflow-y: auto; z-index: 1000; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">
+                  <div v-for="user in jurySearchResults" :key="user.username" class="p-2 border-bottom cursor-pointer"
+                    style="cursor: pointer;" @click="addJury(user.username)">
                     <i class="fas fa-user me-2 text-primary"></i>
                     <strong>{{ user.username }}</strong>
                   </div>
@@ -138,23 +93,13 @@
             <div class="row">
               <div class="col-md-6 mb-3">
                 <label for="marksAccepted" class="form-label">Points for Accepted Submissions</label>
-                <input
-                  type="number"
-                  class="form-control"
-                  id="marksAccepted"
-                  v-model.number="formData.marks_setting_accepted"
-                  min="0"
-                />
+                <input type="number" class="form-control" id="marksAccepted"
+                  v-model.number="formData.marks_setting_accepted" min="0" />
               </div>
               <div class="col-md-6 mb-3">
                 <label for="marksRejected" class="form-label">Points for Rejected Submissions</label>
-                <input
-                  type="number"
-                  class="form-control"
-                  id="marksRejected"
-                  v-model.number="formData.marks_setting_rejected"
-                  min="0"
-                />
+                <input type="number" class="form-control" id="marksRejected"
+                  v-model.number="formData.marks_setting_rejected" min="0" />
               </div>
             </div>
 
@@ -162,24 +107,16 @@
               <label for="codeLink" class="form-label">
                 Code Repository Link <span class="text-muted">(Optional)</span>
               </label>
-              <input
-                type="text"
-                class="form-control"
-                id="codeLink"
-                v-model="formData.code_link"
-                placeholder="https://github.com/..."
-              />
+              <input type="text" class="form-control" id="codeLink" v-model="formData.code_link"
+                placeholder="https://github.com/..." />
             </div>
+
+
           </form>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button
-            type="button"
-            class="btn btn-primary"
-            @click="handleSubmit"
-            :disabled="loading"
-          >
+          <button type="button" class="btn btn-primary" @click="handleSubmit" :disabled="loading">
             <span v-if="loading" class="spinner-border spinner-border-sm me-2"></span>
             Create Contest
           </button>
@@ -216,7 +153,8 @@ export default {
       marks_setting_accepted: 10,
       marks_setting_rejected: 0,
       code_link: null,
-      rules_text: ''
+      rules_text: '',
+      allowed_submission_type: 'both'
     })
 
     // Set default dates
@@ -625,4 +563,3 @@ input[type="date"].form-control {
   border-right-color: transparent;
 }
 </style>
-

--- a/frontend/src/components/SubmitArticleModal.vue
+++ b/frontend/src/components/SubmitArticleModal.vue
@@ -34,6 +34,29 @@
                 Enter the full URL of your MediaWiki article (e.g., Wikipedia, Wikiversity, etc.)
               </small>
             </div>
+            <!-- SUBMISSION TYPE -->
+            <div class="mb-3" v-if="contest">
+              <label class="form-label">
+                <i class="fas fa-edit me-2 text-primary"></i>
+                Submission Type <span class="text-danger">*</span>
+              </label>
+
+              <select v-model="formData.submission_type" class="form-control" required>
+                <option 
+                  value="new"
+                  v-if="contest.allowed_submission_type === 'new' || contest.allowed_submission_type === 'both'"
+                >
+                  New Article
+                </option>
+
+                <option 
+                  value="expansion"
+                  v-if="contest.allowed_submission_type === 'expansion' || contest.allowed_submission_type === 'both'"
+                >
+                  Expansion
+                </option>
+              </select>
+            </div>
 
             <div v-if="error" class="alert alert-danger" role="alert">
               {{ error }}

--- a/frontend/src/views/ContestView.vue
+++ b/frontend/src/views/ContestView.vue
@@ -86,6 +86,33 @@
     </pre>
         </div>
       </div>
+      <div class="card mb-4">
+        <div class="card-header">
+          <h3>Submission Type Allowed</h3>
+        </div>
+        <div class="card-body">
+          <p>
+            <strong>
+              {{
+                contest.allowed_submission_type === 'new'
+                  ? 'New Articles Only'
+                  : contest.allowed_submission_type === 'expansion'
+                    ? 'Improved Articles Only'
+                    : 'Both (New Articles + Improved Articles)'
+              }}
+            </strong>
+          </p>
+
+          <!-- Small explanatory note -->
+          <p class="mt-2 small text-muted">
+            <em>
+              • <strong>New Articles</strong> = Completely new Wikipedia article created during the contest.<br>
+              • <strong>Improved Articles</strong> = An existing article improved or expanded with substantial content.
+            </em>
+          </p>
+        </div>
+      </div>
+
 
       <!-- Jury Members Section -->
       <div v-if="contest.jury_members && contest.jury_members.length > 0" class="card mb-4">
@@ -109,27 +136,19 @@
           </p>
         </div>
       </div>
-
-
-
       <!-- Submissions Section (for jury and contest creators) -->
       <div v-if="canViewSubmissions" class="card mb-4">
         <div class="card-header">
           <div class="d-flex justify-content-between align-items-center">
             <h5 class="mb-0"><i class="fas fa-file-alt me-2"></i>Submissions</h5>
-            <button
-              v-if="loadingSubmissions || refreshingMetadata"
-              class="btn btn-sm btn-outline-secondary"
-              disabled
-            >
+            <button v-if="loadingSubmissions || refreshingMetadata" class="btn btn-sm btn-outline-secondary" disabled>
               <span class="spinner-border spinner-border-sm me-2"></span>
               {{ loadingSubmissions ? 'Loading...' : 'Refreshing...' }}
             </button>
             <button v-else class="btn btn-sm btn-outline-light" @click="refreshMetadata"
               :disabled="submissions.length === 0"
               title="Refresh article metadata (byte count, author, etc.) from MediaWiki and reload submissions"
-              style="color: white; border-color: white;"
-            >
+              style="color: white; border-color: white;">
               <i class="fas fa-database me-1"></i>Refresh Metadata
             </button>
           </div>
@@ -161,11 +180,8 @@
                       <i class="fas fa-eye ms-1" style="font-size: 0.8em;"></i>
                     </a>
                     <!-- Total bytes = Original bytes (at submission) + Expansion bytes (change since submission) -->
-                    <div
-                      v-if="submission.article_word_count !== null &&
-                        submission.article_word_count !== undefined"
-                      class="text-muted small mt-1"
-                    >
+                    <div v-if="submission.article_word_count !== null &&
+                      submission.article_word_count !== undefined" class="text-muted small mt-1">
                       <i class="fas fa-file-alt me-1"></i>Total bytes:
                       {{
                         formatByteCountWithExact(
@@ -174,30 +190,23 @@
                         )
                       }}
                     </div>
-                    <div
-                      v-if="submission.article_word_count !== null &&
-                        submission.article_word_count !== undefined"
-                      class="text-muted small mt-1"
-                    >
+                    <div v-if="submission.article_word_count && submission.article_word_count > 0"
+                      class="text-muted small mt-1">
+                      <i class="fas fa-file-alt me-1"></i>{{ formatWordCount(submission.article_word_count) }}
+                    </div>
+                    <div v-if="submission.article_word_count !== null &&
+                      submission.article_word_count !== undefined" class="text-muted small mt-1">
                       <i class="fas fa-clock me-1"></i>Original bytes:
                       {{ formatByteCountWithExact(submission.article_word_count) }}
                     </div>
                     <!-- Show expansion bytes (0 if no change, +X if increased, -X if decreased) -->
-                    <div
-                      v-if="submission.article_expansion_bytes !== null &&
-                        submission.article_expansion_bytes !== undefined"
-                      class="text-muted small mt-1"
-                    >
-                      <i
-                        v-if="submission.article_expansion_bytes !== 0"
-                        :class="submission.article_expansion_bytes >= 0
-                          ? 'fas fa-arrow-up me-1'
-                          : 'fas fa-arrow-down me-1'"
-                      ></i>Expansion bytes:
-                      <span
-                        v-if="submission.article_expansion_bytes !== 0"
-                        :class="submission.article_expansion_bytes >= 0 ? 'text-success' : 'text-danger'"
-                      >
+                    <div v-if="submission.article_expansion_bytes !== null &&
+                      submission.article_expansion_bytes !== undefined" class="text-muted small mt-1">
+                      <i v-if="submission.article_expansion_bytes !== 0" :class="submission.article_expansion_bytes >= 0
+                        ? 'fas fa-arrow-up me-1'
+                        : 'fas fa-arrow-down me-1'"></i>Expansion bytes:
+                      <span v-if="submission.article_expansion_bytes !== 0"
+                        :class="submission.article_expansion_bytes >= 0 ? 'text-success' : 'text-danger'">
                         {{ submission.article_expansion_bytes >= 0 ? '+' : '-' }}{{
                           formatByteCountWithExact(Math.abs(submission.article_expansion_bytes))
                         }}
@@ -217,19 +226,13 @@
                       <i class="fas fa-calendar me-1"></i>{{ formatDateShort(submission.article_created_at) }}
                     </div>
                     <!-- Latest revision author (from latest revision, shown below original) -->
-                    <div
-                      v-if="submission.latest_revision_author"
-                      class="mt-2 pt-2"
-                      style="border-top: 1px solid #dee2e6;"
-                    >
+                    <div v-if="submission.latest_revision_author" class="mt-2 pt-2"
+                      style="border-top: 1px solid #dee2e6;">
                       <div>
                         <i class="fas fa-user me-1"></i>{{ submission.latest_revision_author }}
                         <span class="badge bg-info ms-1" style="font-size: 0.7em;">Latest</span>
                       </div>
-                      <div
-                        v-if="submission.latest_revision_timestamp"
-                        class="text-muted small mt-1"
-                      >
+                      <div v-if="submission.latest_revision_timestamp" class="text-muted small mt-1">
                         <i class="fas fa-calendar me-1"></i>
                         {{ formatDateShort(submission.latest_revision_timestamp) }}
                       </div>
@@ -325,6 +328,17 @@
               <label class="form-label">Rules</label>
               <textarea v-model="editForm.rules" rows="6" class="form-control"></textarea>
             </div>
+
+            <div class="mb-3">
+              <label class="form-label">Allowed Submission Type</label>
+              <select class="form-control" v-model="editForm.allowed_submission_type">
+                <option value="new">New Articles Only</option>
+                <option value="expansion">Improved Article Only</option>
+                <option value="both">Both (New Article + Improved Article)</option>
+              </select>
+            </div>
+
+
 
             <div class="row">
               <div class="col-md-6 mb-3">
@@ -834,7 +848,8 @@ export default {
       marks_setting_accepted: 0,
       marks_setting_rejected: 0,
       jury_members: '',
-      code_link: ''
+      code_link: '',
+      allowed_submission_type: ''
     })
 
     onMounted(() => {
@@ -853,6 +868,7 @@ export default {
 
 
       editForm.rules = contest.value.rules?.text || "";
+      editForm.allowed_submission_type = contest.value.allowed_submission_type || "both";
 
       editForm.start_date = contest.value.start_date || "";
       editForm.end_date = contest.value.end_date || "";
@@ -887,7 +903,8 @@ export default {
               .split(",")
               .map(x => x.trim())
               .filter(x => x.length > 0),
-          code_link: editForm.code_link?.trim() || null
+          code_link: editForm.code_link?.trim() || null,
+          allowed_submission_type: editForm.allowed_submission_type,
         };
 
         // console.log("FINAL PAYLOAD SENT →", payload);


### PR DESCRIPTION
<img width="1428" height="873" alt="image" src="https://github.com/user-attachments/assets/bb19c695-979e-44be-9d09-5aeb36a92f16" />
- Added a "Type of Submission" option while creating a contest, allowing organizers to choose whether the event focuses on new article submissions or improvements to existing articles.
- Updated Contest View and Edit Contest pages to display and manage the selected submission type.