### PR TITLE
Add byte count range fields to contests and update related logic

### DIFF
--- a/backend/alembic/versions/51004fa44a6b_add_byte_count_range_fields_to_contests.py
+++ b/backend/alembic/versions/51004fa44a6b_add_byte_count_range_fields_to_contests.py
@@ -1,0 +1,35 @@
+"""Add byte count range fields to contests
+
+Revision ID: 51004fa44a6b
+Revises: fc55a0c85ffc
+Create Date: 2025-12-21 07:23:55.291006
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '51004fa44a6b'
+down_revision = 'fc55a0c85ffc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add byte count range fields to contests table
+    # These fields define the allowed byte count range for article submissions
+    # None means no limit (no minimum or no maximum)
+    op.add_column('contests', sa.Column('min_byte_count', sa.Integer(), nullable=True))
+    op.add_column('contests', sa.Column('max_byte_count', sa.Integer(), nullable=True))
+    
+    # Remove old required_bytes column if it exists (legacy field, no longer used)
+    op.drop_column('contests', 'required_bytes')
+
+
+def downgrade() -> None:
+    # Reverse the migration: remove new fields and restore old field
+    op.add_column('contests', sa.Column('required_bytes', mysql.INTEGER(), autoincrement=False, nullable=True))
+    op.drop_column('contests', 'max_byte_count')
+    op.drop_column('contests', 'min_byte_count')
+

--- a/backend/app/models/contest.py
+++ b/backend/app/models/contest.py
@@ -53,6 +53,11 @@ class Contest(BaseModel):
     marks_setting_rejected = db.Column(db.Integer, default=0, nullable=False)
     allowed_submission_type = db.Column(db.String(20), default="both", nullable=False)
 
+    # Byte count range for article submissions
+    # Articles must have byte count between min_byte_count and max_byte_count (inclusive)
+    min_byte_count = db.Column(db.Integer, nullable=True)  # Minimum byte count (None = no minimum)
+    max_byte_count = db.Column(db.Integer, nullable=True)  # Maximum byte count (None = no maximum)
+
     # Jury members (comma-separated usernames)
     jury_members = db.Column(db.Text, nullable=True)
 
@@ -85,6 +90,10 @@ class Contest(BaseModel):
         self.marks_setting_rejected = kwargs.get('marks_setting_rejected', 0)
         self.allowed_submission_type = kwargs.get('allowed_submission_type', 'both')
 
+        # Byte count range (optional - None means no limit)
+        # If provided, articles must have byte count within this range
+        self.min_byte_count = kwargs.get('min_byte_count', None)
+        self.max_byte_count = kwargs.get('max_byte_count', None)
 
         # Handle rules and jury_members
         self.set_rules(kwargs.get('rules', {}))
@@ -138,6 +147,35 @@ class Contest(BaseModel):
         if self.jury_members:
             return [username.strip() for username in self.jury_members.split(',') if username.strip()]
         return []
+
+    def validate_byte_count(self, byte_count):
+        """
+        Validate if article byte count is within the contest's allowed range
+
+        Args:
+            byte_count: Article byte count to validate (can be None)
+
+        Returns:
+            tuple: (is_valid: bool, error_message: str or None)
+                  Returns (True, None) if valid, (False, error_message) if invalid
+        """
+        # If byte count is None, we can't validate it
+        # This might happen if MediaWiki API fails to fetch the size
+        if byte_count is None:
+            # If contest has byte count requirements, we need the value
+            if self.min_byte_count is not None or self.max_byte_count is not None:
+                return False, 'Article byte count could not be determined. Please ensure the article exists and try again.'
+
+        # Check minimum byte count
+        if self.min_byte_count is not None and byte_count < self.min_byte_count:
+            return False, f'Article byte count ({byte_count}) is below the minimum required ({self.min_byte_count} bytes)'
+
+        # Check maximum byte count
+        if self.max_byte_count is not None and byte_count > self.max_byte_count:
+            return False, f'Article byte count ({byte_count}) exceeds the maximum allowed ({self.max_byte_count} bytes)'
+
+        # Byte count is within valid range
+        return True, None
 
     def is_active(self):
         """
@@ -253,6 +291,8 @@ class Contest(BaseModel):
             'marks_setting_accepted': self.marks_setting_accepted,
             'marks_setting_rejected': self.marks_setting_rejected,
             'allowed_submission_type': self.allowed_submission_type,
+            'min_byte_count': self.min_byte_count,
+            'max_byte_count': self.max_byte_count,
             'jury_members': self.get_jury_members(),
             # Format datetime as ISO string with 'Z' suffix to indicate UTC
             # This ensures JavaScript interprets it as UTC, not local time

--- a/backend/scripts/fix_alembic_version.py
+++ b/backend/scripts/fix_alembic_version.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Fix Alembic version table when migration files are missing.
+
+This script updates the alembic_version table to match the actual
+migration files in the repository.
+
+Usage:
+    python scripts/fix_alembic_version.py <target_revision>
+    
+Example:
+    python scripts/fix_alembic_version.py fc55a0c85ffc
+"""
+
+import sys
+import os
+
+# Add the backend directory to Python path
+backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, backend_dir)
+
+from app import create_app
+from app.database import db
+
+def main():
+    """
+    Update alembic_version table to the specified revision.
+    """
+    if len(sys.argv) < 2:
+        print("Usage: python scripts/fix_alembic_version.py <target_revision>")
+        print("\nExample:")
+        print("  python scripts/fix_alembic_version.py fc55a0c85ffc")
+        sys.exit(1)
+    
+    target_revision = sys.argv[1]
+    
+    # Create Flask app to get database connection
+    app = create_app()
+    
+    with app.app_context():
+        try:
+            # Update alembic_version table directly
+            # This bypasses Alembic's normal checks
+            db.session.execute(
+                db.text("UPDATE alembic_version SET version_num = :revision"),
+                {"revision": target_revision}
+            )
+            db.session.commit()
+            
+            print(f"Successfully updated alembic_version to: {target_revision}")
+            print("\nYou can now run:")
+            print("  python -m alembic current")
+            print("  python -m alembic revision --autogenerate -m 'Your message'")
+            
+        except Exception as e:
+            print(f"Error updating alembic_version: {e}")
+            print("\nTroubleshooting:")
+            print("1. Make sure your database is running")
+            print("2. Check your DATABASE_URL in .env file")
+            print("3. Verify the alembic_version table exists")
+            sys.exit(1)
+
+if __name__ == '__main__':
+    main()
+

--- a/frontend/src/components/CreateContestModal.vue
+++ b/frontend/src/components/CreateContestModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="modal fade" id="createContestModal" tabindex="-1">
-    <div class="modal-dialog modal-lg">
+    <div class="modal-dialog modal-fullscreen">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">Create New Contest</h5>
@@ -141,6 +141,33 @@ min="0" />
               </div>
             </div>
 
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                <label for="minByteCount" class="form-label">
+                  Minimum Byte Count <span class="text-muted">(Optional)</span>
+                </label>
+                <input type="number"
+class="form-control"
+id="minByteCount"
+                  v-model.number="formData.min_byte_count"
+min="0"
+                  placeholder="e.g., 1000" />
+                <small class="form-text text-muted">Articles must have at least this many bytes</small>
+              </div>
+              <div class="col-md-6 mb-3">
+                <label for="maxByteCount" class="form-label">
+                  Maximum Byte Count <span class="text-muted">(Optional)</span>
+                </label>
+                <input type="number"
+class="form-control"
+id="maxByteCount"
+                  v-model.number="formData.max_byte_count"
+min="0"
+                  placeholder="e.g., 50000" />
+                <small class="form-text text-muted">Articles must not exceed this many bytes</small>
+              </div>
+            </div>
+
             <div class="mb-3">
               <label for="codeLink" class="form-label">
                 Code Repository Link <span class="text-muted">(Optional)</span>
@@ -198,7 +225,9 @@ export default {
       marks_setting_rejected: 0,
       code_link: null,
       rules_text: '',
-      allowed_submission_type: 'both'
+      allowed_submission_type: 'both',
+      min_byte_count: null,
+      max_byte_count: null
     })
 
     // Set default dates
@@ -285,6 +314,14 @@ export default {
         return
       }
 
+      // Validate byte count range
+      if (formData.min_byte_count !== null && formData.max_byte_count !== null) {
+        if (formData.min_byte_count > formData.max_byte_count) {
+          showAlert('Minimum byte count must be less than or equal to maximum byte count', 'warning')
+          return
+        }
+      }
+
       loading.value = true
       try {
         const contestData = {
@@ -293,7 +330,22 @@ export default {
           code_link: formData.code_link?.trim() || null,
           rules: {
             text: formData.rules_text.trim()
-          }
+          },
+          // Byte count fields: null if not set or invalid, otherwise use the value (including 0)
+          min_byte_count: (
+            formData.min_byte_count === null ||
+            formData.min_byte_count === undefined ||
+            isNaN(formData.min_byte_count)
+          )
+            ? null
+            : Number(formData.min_byte_count),
+          max_byte_count: (
+            formData.max_byte_count === null ||
+            formData.max_byte_count === undefined ||
+            isNaN(formData.max_byte_count)
+          )
+            ? null
+            : Number(formData.max_byte_count)
         }
 
         const result = await store.createContest(contestData)
@@ -327,6 +379,8 @@ export default {
       selectedJury.value = []
       formData.jury_members = []
       formData.rules_text = ''
+      formData.min_byte_count = null
+      formData.max_byte_count = null
 
       // Reset dates
       const today = new Date()
@@ -605,5 +659,43 @@ input[type="date"].form-control {
   border-width: 0.15em;
   border-color: currentColor;
   border-right-color: transparent;
+}
+
+/* Full screen modal styling */
+.modal-fullscreen {
+  width: 100vw;
+  max-width: 100%;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+
+.modal-fullscreen .modal-content {
+  height: 100vh;
+  border: 0;
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-fullscreen .modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+}
+
+/* Better spacing for full screen layout */
+.modal-fullscreen .modal-body .row {
+  margin-bottom: 1rem;
+}
+
+.modal-fullscreen .modal-body .mb-3 {
+  margin-bottom: 1.5rem !important;
+}
+
+/* Ensure form uses available space well */
+.modal-fullscreen .modal-body form {
+  max-width: 1200px;
+  margin: 0 auto;
 }
 </style>

--- a/frontend/src/components/SubmitArticleModal.vue
+++ b/frontend/src/components/SubmitArticleModal.vue
@@ -34,28 +34,87 @@
                 Enter the full URL of your MediaWiki article (e.g., Wikipedia, Wikiversity, etc.)
               </small>
             </div>
-            <!-- SUBMISSION TYPE -->
-            <div class="mb-3" v-if="contest">
+
+            <!-- Validation Checklist -->
+            <div class="mb-3" v-if="contest && (contest.min_byte_count || contest.max_byte_count)">
               <label class="form-label">
-                <i class="fas fa-edit me-2 text-primary"></i>
-                Submission Type <span class="text-danger">*</span>
+                <i class="fas fa-check-circle me-2 text-primary"></i>Validation Checklist
               </label>
+              <div class="card border-primary">
+                <div class="card-body">
+                  <div class="validation-item mb-2" v-for="(item, index) in validationChecklist" :key="index">
+                    <div
+                      class="d-flex align-items-center"
+                      :class="{
+                        'text-success': item.checked,
+                        'text-danger': !item.checked && item.detail,
+                        'text-muted': !item.checked && !item.detail
+                      }"
+                    >
+                      <i
+                        :class="
+                          item.checked
+                            ? 'fas fa-check-circle text-success me-2'
+                            : item.detail
+                            ? 'fas fa-times-circle text-danger me-2'
+                            : 'fas fa-circle text-muted me-2'
+                        "
+                      ></i>
+                      <span class="flex-grow-1">
+                        {{ item.label }}
+                        <span
+                          v-if="item.detail"
+                          :class="{
+                            'text-danger small ms-2': !item.checked,
+                            'text-muted small ms-2': item.checked
+                          }"
+                        >({{ item.detail }})</span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
 
-              <select v-model="formData.submission_type" class="form-control" required>
-                <option
-                  value="new"
-                  v-if="contest.allowed_submission_type === 'new' || contest.allowed_submission_type === 'both'"
-                >
-                  New Article
-                </option>
+            <!-- Progress Indicator -->
+            <div v-if="submissionProgress.stage !== 'idle'" class="mb-3">
+              <div class="card border-primary">
+                <div class="card-body">
+                  <h6 class="card-title mb-3">
+                    <i class="fas fa-tasks me-2"></i>Submission Progress
+                  </h6>
 
-                <option
-                  value="expansion"
-                  v-if="contest.allowed_submission_type === 'expansion' || contest.allowed_submission_type === 'both'"
-                >
-                  Expansion
-                </option>
-              </select>
+                  <!-- Progress Bar -->
+                  <div class="progress mb-3" style="height: 25px;">
+                    <div
+                      class="progress-bar progress-bar-striped progress-bar-animated"
+                      :class="progressBarClass"
+                      role="progressbar"
+                      :style="{ width: progressPercentage + '%' }"
+                    >
+                      {{ progressPercentage }}%
+                    </div>
+                  </div>
+
+                  <!-- Progress Steps -->
+                  <div class="progress-steps">
+                    <div
+                      v-for="(step, index) in progressSteps"
+                      :key="index"
+                      class="progress-step mb-2"
+                      :class="{ 'active': step.active, 'completed': step.completed, 'failed': step.failed }"
+                    >
+                      <i
+                        :class="step.icon"
+                        class="me-2"
+                        :style="{ color: step.iconColor }"
+                      ></i>
+                      <span>{{ step.label }}</span>
+                      <span v-if="step.detail" class="text-muted ms-2 small">({{ step.detail }})</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <div v-if="error" class="alert alert-danger" role="alert">
@@ -71,7 +130,7 @@
             type="button"
             class="btn btn-primary"
             @click="handleSubmit"
-            :disabled="loading"
+            :disabled="loading || !canSubmit"
           >
             <span v-if="loading" class="spinner-border spinner-border-sm me-2"></span>
             <i v-else class="fas fa-paper-plane me-2"></i>Submit Article
@@ -83,7 +142,7 @@
 </template>
 
 <script>
-import { ref, reactive } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { showAlert } from '../utils/alerts'
 import api from '../services/api'
 
@@ -99,45 +158,411 @@ export default {
   setup(props, { emit }) {
     const loading = ref(false)
     const error = ref('')
+    const contest = ref(null)
 
     const formData = reactive({
       article_link: ''
     })
 
-    const handleSubmit = async () => {
-      error.value = ''
+    // Validation checklist state
+    const validationChecklist = reactive([
+      {
+        label: 'Article URL is valid',
+        checked: false,
+        detail: null
+      },
+      {
+        label: 'Article byte count is within required range',
+        checked: false,
+        detail: null
+      }
+    ])
 
-      // Validation
+    // Submission progress tracking
+    const submissionProgress = reactive({
+      stage: 'idle', // 'idle', 'fetching', 'validating', 'submitting', 'success', 'error'
+      articleByteCount: null,
+      contestByteRequirements: null
+    })
+
+    // Load contest details to get byte count requirements
+    const loadContest = async () => {
+      try {
+        const data = await api.get(`/contest/${props.contestId}`)
+        contest.value = data
+        submissionProgress.contestByteRequirements = {
+          min: data.min_byte_count,
+          max: data.max_byte_count
+        }
+      } catch (err) {
+        console.error('Error loading contest:', err)
+      }
+    }
+
+    onMounted(() => {
+      loadContest()
+    })
+
+    // Debounce timer for URL validation
+    let validationTimer = null
+
+    // Watch for URL changes and validate automatically
+    // This provides real-time feedback as user enters the URL
+    watch(
+      () => formData.article_link,
+      (newUrl) => {
+        // Clear any existing timer
+        if (validationTimer) {
+          clearTimeout(validationTimer)
+        }
+
+        // Reset checklist when URL is cleared
+        if (!newUrl || !newUrl.trim()) {
+          validationChecklist[0].checked = false
+          validationChecklist[0].detail = null
+          validationChecklist[1].checked = false
+          validationChecklist[1].detail = null
+          return
+        }
+
+        // Debounce validation - wait 800ms after user stops typing
+        // This prevents too many API calls while user is typing
+        validationTimer = setTimeout(async () => {
+          // Only validate if URL looks like a valid URL (starts with http)
+          if (newUrl.trim().startsWith('http://') || newUrl.trim().startsWith('https://')) {
+            // Wait for contest to be loaded before validating
+            // This ensures we have byte count requirements available
+            if (!contest.value) {
+              await loadContest()
+            }
+            // Validate silently (without showing progress indicators)
+            await validateArticle(false)
+          } else {
+            // URL format is invalid, just mark URL check as failed
+            validationChecklist[0].checked = false
+            validationChecklist[0].detail = 'URL must start with http:// or https://'
+            validationChecklist[1].checked = false
+            validationChecklist[1].detail = null
+          }
+        }, 800)
+      }
+    )
+
+    // Progress steps based on current stage
+    const progressSteps = computed(() => {
+      const steps = [
+        {
+          label: 'Fetching article information',
+          icon: 'fas fa-spinner fa-spin',
+          iconColor: '#006699',
+          active: submissionProgress.stage === 'fetching',
+          completed: ['validating', 'submitting', 'success'].includes(submissionProgress.stage),
+          failed: false,
+          detail: submissionProgress.stage === 'fetching' ? 'Getting article details from MediaWiki...' : null
+        },
+        {
+          label: 'Checking byte count requirements',
+          icon: 'fas fa-check-circle',
+          iconColor: '#28a745',
+          active: submissionProgress.stage === 'validating',
+          completed: ['submitting', 'success'].includes(submissionProgress.stage),
+          failed: submissionProgress.stage === 'error' && error.value.includes('byte count'),
+          detail: getByteCountDetail()
+        },
+        {
+          label: 'Submitting article',
+          icon: 'fas fa-paper-plane',
+          iconColor: '#006699',
+          active: submissionProgress.stage === 'submitting',
+          completed: submissionProgress.stage === 'success',
+          failed: submissionProgress.stage === 'error' && !error.value.includes('byte count'),
+          detail: submissionProgress.stage === 'submitting' ? 'Creating submission...' : null
+        }
+      ]
+      return steps
+    })
+
+    // Get byte count detail text
+    const getByteCountDetail = () => {
+      if (submissionProgress.stage === 'idle' || submissionProgress.stage === 'fetching') {
+        return null
+      }
+
+      const req = submissionProgress.contestByteRequirements
+      const count = submissionProgress.articleByteCount
+
+      if (!req || (!req.min && !req.max)) {
+        return 'No byte count restrictions'
+      }
+
+      if (count !== null) {
+        const minText = req.min ? `min: ${req.min.toLocaleString()}` : ''
+        const maxText = req.max ? `max: ${req.max.toLocaleString()}` : ''
+        const rangeText = [minText, maxText].filter(Boolean).join(', ')
+        return `Article: ${count.toLocaleString()} bytes | Required: ${rangeText}`
+      }
+
+      return 'Checking...'
+    }
+
+    // Progress percentage
+    const progressPercentage = computed(() => {
+      switch (submissionProgress.stage) {
+        case 'fetching':
+          return 33
+        case 'validating':
+          return 66
+        case 'submitting':
+          return 90
+        case 'success':
+          return 100
+        case 'error':
+          return 0
+        default:
+          return 0
+      }
+    })
+
+    // Progress bar class
+    const progressBarClass = computed(() => {
+      if (submissionProgress.stage === 'error') {
+        return 'bg-danger'
+      }
+      if (submissionProgress.stage === 'success') {
+        return 'bg-success'
+      }
+      return 'bg-primary'
+    })
+
+    // Check if all validations have passed - used to enable/disable submit button
+    const canSubmit = computed(() => {
+      // If contest has no byte count requirements, only URL validation is needed
+      if (!contest.value || (!contest.value.min_byte_count && !contest.value.max_byte_count)) {
+        return validationChecklist[0].checked
+      }
+      // If contest has byte count requirements, both checks must pass
+      return validationChecklist[0].checked && validationChecklist[1].checked
+    })
+
+    // Validate article before submission
+    // showProgress: if true, shows progress indicators; if false, just updates checklist silently
+    const validateArticle = async (showProgress = true) => {
+      // Reset checklist
+      validationChecklist[0].checked = false
+      validationChecklist[0].detail = null
+      validationChecklist[1].checked = false
+      validationChecklist[1].detail = null
+
+      // Check 1: Validate URL format
       if (!formData.article_link.trim()) {
-        error.value = 'Please enter an article URL'
-        return
+        validationChecklist[0].checked = false
+        validationChecklist[0].detail = 'URL is required'
+        return false
       }
       if (!formData.article_link.startsWith('http://') && !formData.article_link.startsWith('https://')) {
-        error.value = 'Article URL must start with http:// or https://'
+        validationChecklist[0].checked = false
+        validationChecklist[0].detail = 'URL must start with http:// or https://'
+        return false
+      }
+
+      // URL is valid
+      validationChecklist[0].checked = true
+      validationChecklist[0].detail = 'Valid URL format'
+
+      // Check 2: Fetch article info and validate byte count
+      try {
+        if (showProgress) {
+          submissionProgress.stage = 'fetching'
+        }
+        // Note: baseURL is already '/api', so we use '/mediawiki/article-info' not '/api/mediawiki/article-info'
+        // Make API call to fetch article information
+        const articleInfo = await api.get('/mediawiki/article-info', {
+          params: { url: formData.article_link.trim() }
+        })
+
+        // Check if API returned an error in the response
+        if (articleInfo.error) {
+          throw new Error(articleInfo.error)
+        }
+
+        // Get byte count from article info (word_count is actually byte count)
+        const articleByteCount = articleInfo.word_count || articleInfo.size || null
+        submissionProgress.articleByteCount = articleByteCount
+
+        // Check if contest has byte count requirements
+        // If contest is not loaded yet, try to load it
+        if (!contest.value || !submissionProgress.contestByteRequirements) {
+          await loadContest()
+        }
+
+        const req = submissionProgress.contestByteRequirements
+
+        // If article byte count is null, we can't validate
+        if (articleByteCount === null) {
+          validationChecklist[1].checked = false
+          validationChecklist[1].detail = 'Could not determine article size'
+          return false
+        }
+
+        // Validate byte count against contest requirements
+        // Only validate if contest has byte count requirements
+        if (req && (req.min !== null || req.max !== null)) {
+          let isValid = true
+          let errorMessage = null
+
+          // Check minimum byte count - show exact error message matching backend format
+          if (req.min !== null && articleByteCount < req.min) {
+            isValid = false
+            errorMessage = `Article byte count (${articleByteCount.toLocaleString()}) is below the minimum required (${req.min.toLocaleString()} bytes)`
+          }
+          // Check maximum byte count - show exact error message matching backend format
+          if (req.max !== null && articleByteCount > req.max) {
+            isValid = false
+            errorMessage = `Article byte count (${articleByteCount.toLocaleString()}) exceeds the maximum allowed (${req.max.toLocaleString()} bytes)`
+          }
+
+          if (isValid) {
+            validationChecklist[1].checked = true
+            const minText = req.min ? `min: ${req.min.toLocaleString()}` : ''
+            const maxText = req.max ? `max: ${req.max.toLocaleString()}` : ''
+            const rangeText = [minText, maxText].filter(Boolean).join(', ')
+            validationChecklist[1].detail = `${articleByteCount.toLocaleString()} bytes (Required: ${rangeText})`
+            return true
+          } else {
+            validationChecklist[1].checked = false
+            // Show the exact error message with article byte count
+            validationChecklist[1].detail = errorMessage
+            return false
+          }
+        } else {
+          // No byte count requirements
+          validationChecklist[1].checked = true
+          validationChecklist[1].detail = `${articleByteCount.toLocaleString()} bytes (No restrictions)`
+          return true
+        }
+      } catch (err) {
+        validationChecklist[1].checked = false
+        if (showProgress) {
+          submissionProgress.stage = 'error'
+        }
+
+        // Provide better error messages based on error type
+        let errorMsg = 'Failed to fetch article information'
+
+        // Check for different error types
+        const status = err.status || err.response?.status
+        const errorData = err.response?.data || {}
+        const errorMessage = errorData.error || err.message || ''
+
+        // Log error for debugging
+        console.error('Article validation error:', {
+          status,
+          message: errorMessage,
+          error: err
+        })
+
+        if (status === 404) {
+          // Check if it's an article not found or endpoint issue
+          if (errorMessage.toLowerCase().includes('article not found') ||
+              errorMessage.toLowerCase().includes('page not found')) {
+            errorMsg = 'Article not found - please check the URL'
+          } else {
+            errorMsg = 'Article not found or endpoint unavailable'
+          }
+        } else if (status === 0 || err.message?.includes('Network Error') ||
+                   err.message?.includes('Failed to fetch') ||
+                   err.message?.includes('Network request failed')) {
+          errorMsg = 'Network error - please check your connection'
+        } else if (status === 502 || status === 503 || status === 504) {
+          errorMsg = 'Server error - please try again later'
+        } else if (errorMessage) {
+          // Use the actual error message from the API
+          errorMsg = errorMessage
+        } else if (err.message) {
+          errorMsg = err.message
+        }
+
+        validationChecklist[1].detail = errorMsg
+        return false
+      }
+    }
+
+    const handleSubmit = async () => {
+      // Clear any previous errors
+      error.value = ''
+
+      // Check if validation has already passed - if so, skip re-validation
+      // This prevents UI freezing by avoiding duplicate API calls
+      const alreadyValidated = canSubmit.value
+
+      if (!alreadyValidated) {
+        // Validation hasn't passed yet, show error
+        const failedChecks = validationChecklist.filter(item => !item.checked)
+        if (failedChecks.length > 0) {
+          error.value = `Validation failed: ${failedChecks.map(item => item.label).join(', ')}`
+        } else {
+          error.value = 'Please wait for validation to complete or check the requirements.'
+        }
         return
       }
 
+      // Set loading state immediately to prevent multiple clicks
       loading.value = true
+      submissionProgress.stage = 'submitting'
+
       try {
-        // Submit only the URL - backend will fetch article information
+        // Submit the article directly since validation already passed
+        // No need to re-validate - we already checked when URL was entered
         await api.post(`/contest/${props.contestId}/submit`, {
           article_link: formData.article_link.trim()
         })
 
+        // Success - update stage
+        submissionProgress.stage = 'success'
+
+        // Reset loading state immediately
+        loading.value = false
+
         showAlert('Article submitted successfully!', 'success')
+
+        // Emit event to parent to refresh data
         emit('submitted')
 
-        // Close modal
+        // Close modal immediately and reset
         const modalElement = document.getElementById('submitArticleModal')
         const modal = bootstrap.Modal.getInstance(modalElement)
         if (modal) {
           modal.hide()
         }
 
-        // Reset form
+        // Reset form and progress immediately
         formData.article_link = ''
+        submissionProgress.stage = 'idle'
+        submissionProgress.articleByteCount = null
+        validationChecklist[0].checked = false
+        validationChecklist[0].detail = null
+        validationChecklist[1].checked = false
+        validationChecklist[1].detail = null
+        error.value = ''
       } catch (err) {
-        error.value = 'Failed to submit article: ' + err.message
+        submissionProgress.stage = 'error'
+
+        // Extract error message
+        const errorMessage = err.message || 'Failed to submit article'
+        error.value = errorMessage
+
+        // If error is about byte count, update validation checklist
+        if (errorMessage.toLowerCase().includes('byte count')) {
+          // Mark byte count validation as failed
+          validationChecklist[1].checked = false
+          validationChecklist[1].detail = errorMessage
+          // Try to extract byte count from error if available
+          const byteMatch = errorMessage.match(/(\d+)\s*bytes?/i)
+          if (byteMatch) {
+            submissionProgress.articleByteCount = parseInt(byteMatch[1])
+          }
+        }
+
         showAlert(error.value, 'danger')
       } finally {
         loading.value = false
@@ -148,7 +573,14 @@ export default {
       formData,
       loading,
       error,
-      handleSubmit
+      handleSubmit,
+      submissionProgress,
+      progressSteps,
+      progressPercentage,
+      progressBarClass,
+      contest,
+      validationChecklist,
+      canSubmit
     }
   }
 }
@@ -316,6 +748,128 @@ export default {
   border-width: 0.15em;
   border-color: currentColor;
   border-right-color: transparent;
+}
+
+/* Progress Indicator Styling */
+.progress-steps {
+  font-size: 0.9rem;
+}
+
+.progress-step {
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  transition: all 0.3s ease;
+}
+
+.progress-step.active {
+  background-color: rgba(0, 102, 153, 0.1);
+  font-weight: 500;
+}
+
+.progress-step.completed {
+  color: #28a745;
+}
+
+.progress-step.completed .fas {
+  color: #28a745 !important;
+}
+
+.progress-step.failed {
+  color: #dc3545;
+}
+
+.progress-step.failed .fas {
+  color: #dc3545 !important;
+}
+
+.progress-step .fas {
+  transition: color 0.3s ease;
+}
+
+/* Progress bar styling */
+.progress {
+  background-color: rgba(0, 102, 153, 0.1);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.progress-bar {
+  transition: width 0.6s ease;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Card styling for progress */
+.card.border-primary {
+  border-color: var(--wiki-primary) !important;
+  background-color: var(--wiki-card-bg);
+  transition: background-color 0.3s ease;
+}
+
+.card-title {
+  color: var(--wiki-text);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .progress-step.active {
+  background-color: rgba(93, 184, 230, 0.15);
+}
+
+[data-theme="dark"] .progress {
+  background-color: rgba(93, 184, 230, 0.1);
+}
+
+/* Validation Checklist Styling */
+.form-check {
+  padding: 0.75rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.2s ease;
+}
+
+.form-check:hover {
+  background-color: rgba(0, 102, 153, 0.05);
+}
+
+[data-theme="dark"] .form-check:hover {
+  background-color: rgba(93, 184, 230, 0.1);
+}
+
+.form-check-input {
+  margin-top: 0.35rem;
+  cursor: not-allowed;
+}
+
+.form-check-label {
+  cursor: default;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.form-check-label.text-success {
+  color: #28a745 !important;
+}
+
+.form-check-label.text-muted {
+  color: var(--wiki-text-muted) !important;
+}
+
+.form-check-label .fas {
+  font-size: 1rem;
+  transition: transform 0.2s ease;
+}
+
+.form-check-label.text-success .fas {
+  color: #28a745 !important;
+}
+
+.card.border-primary .card-body {
+  padding: 1rem;
+  background-color: var(--wiki-card-bg);
+  transition: background-color 0.3s ease;
 }
 </style>
 


### PR DESCRIPTION
- Introduced `min_byte_count` and `max_byte_count` fields in the `Contest` model to define the allowed byte count range for article submissions.
- Updated contest creation and update routes to handle new byte count fields, including validation for non-negative values and ensuring minimum is less than or equal to maximum.
- Enhanced the `validate_byte_count` method to check if article byte count meets contest requirements.
- Modified frontend components to include input fields for byte count range and validation feedback during article submission.
- Added a validation checklist in the submission modal to inform users about byte count requirements and their status during submission.

<img width="965" height="879" alt="image" src="https://github.com/user-attachments/assets/23cba5cf-8b99-4784-b0b2-b3f40d32497d" />

<img width="764" height="863" alt="image" src="https://github.com/user-attachments/assets/e90c8acc-0551-434d-9509-2d38cf28c233" />


<img width="776" height="958" alt="image" src="https://github.com/user-attachments/assets/3ff04daa-6112-4c57-83a3-35b861841dd7" />
