### PR TITLE
Remove code link from contests model and related components

### DIFF
--- a/backend/alembic/versions/81e35234e74d_remove_code_link_from_contests.py
+++ b/backend/alembic/versions/81e35234e74d_remove_code_link_from_contests.py
@@ -1,0 +1,33 @@
+"""remove_code_link_from_contests
+
+Revision ID: 81e35234e74d
+Revises: eb62079dd965
+Create Date: 2025-12-29 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '81e35234e74d'
+down_revision = 'eb62079dd965'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop code_link column from contests table
+    # Check if column exists before dropping to handle partial migration scenarios
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [col['name'] for col in inspector.get_columns('contests')]
+    
+    if 'code_link' in columns:
+        op.drop_column('contests', 'code_link')
+
+
+def downgrade() -> None:
+    # Restore code_link column
+    op.add_column('contests', sa.Column('code_link', sa.String(length=500), nullable=True))
+

--- a/backend/app/models/contest.py
+++ b/backend/app/models/contest.py
@@ -17,7 +17,6 @@ class Contest(BaseModel):
     Attributes:
         id: Primary key, auto-incrementing integer
         name: Name of the contest
-        code_link: Optional link to contest's code repository
         project_name: Name of the associated project (e.g., 'Wikimedia')
         created_by: Username of the user who created the contest
         description: Description of the contest
@@ -37,7 +36,6 @@ class Contest(BaseModel):
 
     # Contest basic information
     name = db.Column(db.String(200), nullable=False)
-    code_link = db.Column(db.String(500), nullable=True)
     project_name = db.Column(db.String(100), nullable=False)
 
     # Contest creator (foreign key to users.username)
@@ -87,20 +85,12 @@ class Contest(BaseModel):
         self.created_by = created_by
 
         # Set optional attributes
-        self.code_link = kwargs.get("code_link")
         self.description = kwargs.get("description")
         self.start_date = kwargs.get("start_date")
         self.end_date = kwargs.get("end_date")
         self.marks_setting_accepted = kwargs.get("marks_setting_accepted", 0)
         self.marks_setting_rejected = kwargs.get("marks_setting_rejected", 0)
         self.allowed_submission_type = kwargs.get("allowed_submission_type", "both")
-        self.code_link = kwargs.get('code_link')
-        self.description = kwargs.get('description')
-        self.start_date = kwargs.get('start_date')
-        self.end_date = kwargs.get('end_date')
-        self.marks_setting_accepted = kwargs.get('marks_setting_accepted', 0)
-        self.marks_setting_rejected = kwargs.get('marks_setting_rejected', 0)
-        self.allowed_submission_type = kwargs.get('allowed_submission_type', 'both')
 
         # Byte count range (optional - None means no limit)
         # If provided, articles must have byte count within this range
@@ -300,7 +290,6 @@ class Contest(BaseModel):
         return {
             'id': self.id,
             'name': self.name,
-            'code_link': self.code_link,
             'project_name': self.project_name,
             'created_by': self.created_by,
             'description': self.description,

--- a/backend/app/routes/contest_routes.py
+++ b/backend/app/routes/contest_routes.py
@@ -89,7 +89,6 @@ def create_contest():
         name: Name of the contest
         project_name: Name of the associated project
         jury_members: List of jury member usernames
-        code_link: Optional link to contest's code repository
         description: Optional description of the contest
         start_date: Optional start date (YYYY-MM-DD)
         end_date: Optional end date (YYYY-MM-DD)
@@ -126,13 +125,6 @@ def create_contest():
         return jsonify({'error': f'These jury members do not exist: {", ".join(missing_users)}'}), 400
 
     # Parse optional fields
-    # Handle code_link: can be None (from frontend), empty string, or a URL
-    code_link_value = data.get('code_link')
-    if code_link_value is None or code_link_value == '':
-        code_link = None
-    else:
-        code_link = str(code_link_value).strip() or None
-
     # Handle description: can be None, empty string, or text
     description_value = data.get('description')
     if description_value is None or description_value == '':
@@ -197,7 +189,6 @@ def create_contest():
             name=name,
             project_name=project_name,
             created_by=user.username,
-            code_link=code_link,
             description=description,
             start_date=start_date,
             end_date=end_date,
@@ -478,11 +469,6 @@ def update_contest(contest_id):  # pylint: disable=too-many-return-statements
                 contest.set_jury_members(arr)
             else:
                 contest.set_jury_members([])
-
-        # --- Code link ---
-        if 'code_link' in data:
-            link = data.get('code_link')
-            contest.code_link = link.strip() if isinstance(link, str) and link.strip() else None
 
         # Persist
         db.session.add(contest)

--- a/frontend/src/components/CreateContestModal.vue
+++ b/frontend/src/components/CreateContestModal.vue
@@ -179,18 +179,6 @@ min="0"
               </div>
             </div>
 
-            <div class="mb-3">
-              <label for="codeLink" class="form-label">
-                Code Repository Link <span class="text-muted">(Optional)</span>
-              </label>
-              <input type="text"
-class="form-control"
-id="codeLink"
-v-model="formData.code_link"
-                placeholder="https://github.com/..." />
-            </div>
-
-
           </form>
         </div>
         <div class="modal-footer">
@@ -249,7 +237,6 @@ export default {
       jury_members: [],
       marks_setting_accepted: 10,
       marks_setting_rejected: 0,
-      code_link: null,
       rules_text: '',
       allowed_submission_type: 'both',
       min_byte_count: null,
@@ -436,7 +423,6 @@ export default {
         const contestData = {
           ...formData,
           jury_members: selectedJury.value,
-          code_link: formData.code_link?.trim() || null,
           rules: {
             text: formData.rules_text.trim()
           },
@@ -484,7 +470,6 @@ export default {
       formData.name = ''
       formData.project_name = ''
       formData.description = ''
-      formData.code_link = null
       selectedJury.value = []
       formData.jury_members = []
       formData.rules_text = ''

--- a/frontend/src/views/ContestView.vue
+++ b/frontend/src/views/ContestView.vue
@@ -135,22 +135,6 @@ class="btn btn-danger"
           <p>{{ contest.jury_members.join(', ') }}</p>
         </div>
       </div>
-      <div class="card mb-4">
-        <div class="card-header">
-          <label class="form-label">Code Link</label>
-        </div>
-        <div class="card-body">
-          <p class="code-link-text">
-            <a v-if="contest.code_link"
-:href="contest.code_link"
-target="_blank"
-rel="noopener noreferrer">
-              {{ contest.code_link }}
-            </a>
-            <span v-else class="text-muted">No code link provided</span>
-          </p>
-        </div>
-      </div>
 
       <!-- Submissions Section (for jury and contest creators) -->
       <div v-if="canViewSubmissions" class="card mb-4">
@@ -450,14 +434,6 @@ style="cursor: pointer;"
             <div class="mb-3">
               <label class="form-label">Rejected Points</label>
               <input type="number" v-model.number="editForm.marks_setting_rejected" class="form-control" />
-            </div>
-
-            <div class="mb-3">
-              <label class="form-label">Code Link (optional)</label>
-              <input type="text"
-class="form-control"
-v-model="editForm.code_link"
-                placeholder="Optional: Add Code Link" />
             </div>
 
           </form>
@@ -967,7 +943,6 @@ export default {
       marks_setting_accepted: 0,
       marks_setting_rejected: 0,
       jury_members: '',
-      code_link: '',
       allowed_submission_type: '',
       selectedJuryMembers: []
     })
@@ -1074,10 +1049,6 @@ export default {
       jurySearchQuery.value = ''
       jurySearchResults.value = []
 
-
-      editForm.code_link = contest.value?.code_link ?? ''
-
-
       editModal.show()
     }
 
@@ -1094,7 +1065,6 @@ export default {
           marks_setting_accepted: Number(editForm.marks_setting_accepted) || 0,
           marks_setting_rejected: Number(editForm.marks_setting_rejected) || 0,
           jury_members: editForm.selectedJuryMembers,
-          code_link: editForm.code_link?.trim() || null,
           allowed_submission_type: editForm.allowed_submission_type
         }
 


### PR DESCRIPTION
- Deleted the `code_link` attribute from the `Contest` model and updated associated routes and frontend components to reflect this change.
- Added a migration script to drop the `code_link` column from the `contests` table, ensuring backward compatibility with a downgrade option to restore the column if needed.