### PR TITLE
Add categories to contests

### DIFF
--- a/backend/alembic/versions/1fa03cdd51b_add_categories_to_contests.py
+++ b/backend/alembic/versions/1fa03cdd51b_add_categories_to_contests.py
@@ -1,0 +1,55 @@
+"""add_categories_to_contests
+
+Revision ID: 1fa03cdd51b
+Revises: a1b2c3d4e5f6
+Create Date: 2025-12-29 14:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '1fa03cdd51b'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add categories column to contests table
+    # Categories will be stored as JSON array of category URLs in TEXT column
+    # Check if column exists before adding to handle partial migration scenarios
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [col['name'] for col in inspector.get_columns('contests')]
+    
+    if 'categories' not in columns:
+        from sqlalchemy import text
+        # MySQL doesn't allow default values for TEXT columns
+        # So we add it as nullable first, then update existing rows, then make it NOT NULL
+        op.add_column('contests', sa.Column('categories', sa.Text(), nullable=True))
+        
+        # Update any existing rows to have empty array
+        conn.execute(text("UPDATE contests SET categories = '[]' WHERE categories IS NULL OR categories = ''"))
+        
+        # Now make it NOT NULL
+        dialect_name = conn.dialect.name
+        if dialect_name == 'mysql':
+            conn.execute(text("ALTER TABLE contests MODIFY COLUMN categories TEXT NOT NULL"))
+        else:
+            op.alter_column('contests', 'categories',
+                            existing_type=sa.Text(),
+                            nullable=False,
+                            existing_nullable=True)
+
+
+def downgrade() -> None:
+    # Remove categories column
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [col['name'] for col in inspector.get_columns('contests')]
+    
+    if 'categories' in columns:
+        op.drop_column('contests', 'categories')
+


### PR DESCRIPTION
- Introduced a new migration to add a `categories` column to the `contests` table, allowing storage of MediaWiki category URLs as a JSON array.
- Updated the `Contest` model to include the `categories` attribute, ensuring it is required and properly handled.
- Enhanced contest creation and update routes to validate category URLs, ensuring at least one valid URL is provided.
- Modified frontend components to support category input, including dynamic addition and removal of category fields, with validation for HTTP/HTTPS URLs.
- Displayed required categories in the contest view, ensuring users are informed of the necessary categories for submissions.

<img width="1234" height="931" alt="image" src="https://github.com/user-attachments/assets/4c54ce80-9146-46ef-b1c3-aa6d87381ee5" />
