### PR TITLE
feat: Add multiple organizer support with management UI

### DIFF
--- a/backend/alembic/versions/add_organizers_column.py
+++ b/backend/alembic/versions/add_organizers_column.py
@@ -1,0 +1,62 @@
+"""add_organizers_column
+
+Revision ID: 7b8c9d0e1f2a
+Revises: 549b0e507d5d
+Create Date: 2025-01-07 14:00:00
+
+This migration adds organizers column to contests table.
+Organizers are stored as comma-separated usernames, similar to jury_members.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '7b8c9d0e1f2a'
+down_revision = '549b0e507d5d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Add organizers column to contests table.
+    
+    This migration:
+    1. Adds organizers column (comma-separated usernames)
+    2. Migrates existing creators as organizers
+    3. Maintains created_by field for backward compatibility
+    """
+    
+    # Add organizers column
+    op.add_column(
+        'contests',
+        sa.Column(
+            'organizers',
+            sa.Text(),
+            nullable=True,
+            comment='Comma-separated list of organizer usernames'
+        )
+    )
+    
+    # Data migration: Set organizers to include creator
+    # For existing contests, creator becomes the first organizer
+    connection = op.get_bind()
+    connection.execute(
+        sa.text("""
+            UPDATE contests
+            SET organizers = created_by
+            WHERE organizers IS NULL OR organizers = ''
+        """)
+    )
+
+
+def downgrade():
+    """
+    Remove organizers column.
+    
+    WARNING: This will delete all organizer data except the original creator
+    (which is preserved in created_by field).
+    """
+    op.drop_column('contests', 'organizers')

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -176,6 +176,32 @@ class User(BaseModel):
             bool: True if user created contest, False otherwise
         """
         return self.username == contest.created_by
+    
+    def is_contest_organizer(self, contest):
+      """
+      Check if user is an organizer for a specific contest
+      
+      Args:
+          contest: Contest instance to check
+      
+      Returns:
+          bool: True if user is organizer, False otherwise
+      """
+      if not contest:
+          return False
+      
+      # Get organizers list from contest
+      organizers = contest.get_organizers()
+      if not organizers:
+          return False
+      
+      # Normalize usernames for comparison (case-insensitive)
+      username_lower = self.username.strip().lower()
+      organizer_usernames = [org.strip().lower() for org in organizers]
+      
+      return username_lower in organizer_usernames
+
+
 
     def can_access_submission(self, submission):
         """
@@ -201,6 +227,9 @@ class User(BaseModel):
 
         # Contest creators can access submissions in their contests
         if self.is_contest_creator(submission.contest):
+            return True
+        # Contest organizers can access submissions in their contests
+        if self.is_contest_organizer(submission.contest):
             return True
 
         return False


### PR DESCRIPTION
<img width="1642" height="612" alt="image" src="https://github.com/user-attachments/assets/bf375191-6b28-4b85-891f-069301a89999" />
- Add organizer management in contest edit modal
- Implement organizer search with autocomplete
- Display organizer avatars with initials in contest cards
- Support adding/removing organizers from contests
- Show organizer list in contest details view
- Add organizer selection UI similar to jury members