### PR TITLE
feat: add automated scoring database support

### DIFF
--- a/backend/alembic/versions/0f85a2313fbd_add_automated_settings_column.py
+++ b/backend/alembic/versions/0f85a2313fbd_add_automated_settings_column.py
@@ -1,0 +1,61 @@
+"""add_automated_settings_column
+
+Revision ID: 0f85a2313fbd
+Revises: 2b7c1a9d4c3e
+Create Date: 2026-03-17
+
+Adds automated_settings column to contests table for automated scoring mode.
+This column stores eligibility criteria and evaluation parameters as JSON.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '0f85a2313fbd'
+down_revision = '2b7c1a9d4c3e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Add automated_settings column to contests table.
+    
+    Structure stored as JSON:
+    {
+        "enabled": true,
+        "eligibility": {
+            "min_edits": 100,
+            "min_bytes": 5000,
+            "min_incoming_links": 2,
+            "min_outgoing_links": 3
+        },
+        "evaluation": {
+            "points_per_accepted": 10,
+            "points_per_byte": 0.001,
+            "points_per_incoming_link": 2,
+            "points_per_outgoing_link": 1,
+            "points_per_category": 1,
+            "points_per_new_reference": 3,
+            "points_per_reused_reference": 1,
+            "points_per_infobox": 5,
+            "points_per_image": 2
+        }
+    }
+    """
+    op.add_column(
+        'contests',
+        sa.Column(
+            'automated_settings',
+            sa.Text(),
+            nullable=True,
+            comment='Automated scoring configuration (eligibility + evaluation criteria)'
+        )
+    )
+
+
+def downgrade():
+    """Remove automated_settings column from contests table."""
+    op.drop_column('contests', 'automated_settings')

--- a/backend/alembic/versions/0f85a2313fbd_add_automated_settings_column.py
+++ b/backend/alembic/versions/0f85a2313fbd_add_automated_settings_column.py
@@ -28,8 +28,6 @@ def upgrade():
         "enabled": true,
         "eligibility": {
             "min_edits": 100,
-            "min_bytes": 5000,
-            "min_incoming_links": 2,
             "min_outgoing_links": 3
         },
         "evaluation": {

--- a/backend/app/models/contest.py
+++ b/backend/app/models/contest.py
@@ -71,6 +71,10 @@ class Contest(BaseModel, ContestMixin):
     # Multi-parameter scoring configuration (stored as JSON string)
     scoring_parameters = db.Column(db.Text, nullable=True)
 
+    # Automated scoring configuration (stored as JSON string)
+    # Contains eligibility criteria and evaluation parameters
+    automated_settings = db.Column(db.Text, nullable=True)
+
     # Submission type restriction: 'new', 'expansion', or 'both'
     allowed_submission_type = db.Column(db.String(20), default="both", nullable=False)
 
@@ -154,6 +158,9 @@ class Contest(BaseModel, ContestMixin):
 
         # Set scoring configuration (handles validation internally)
         self.set_scoring_parameters(kwargs.get("scoring_parameters"))
+
+        # Set automated scoring configuration (handles validation internally)
+        self.set_automated_settings(kwargs.get("automated_settings"))
 
         # Set article requirements
         self.min_byte_count = kwargs.get("min_byte_count", 0)
@@ -563,8 +570,13 @@ class Contest(BaseModel, ContestMixin):
         Get the current scoring mode for this contest.
 
         Returns:
-            str: 'simple' or 'multi_parameter'
+            str: 'simple', 'multi_parameter', or 'automated'
         """
+        # Check for automated scoring mode first
+        automated = self.get_automated_settings()
+        if automated and automated.get("enabled") is True:
+            return "automated"
+        # Then check for multi-parameter scoring
         params = self.get_scoring_parameters()
         if params and params.get("enabled") is True:
             return "multi_parameter"
@@ -607,6 +619,8 @@ class Contest(BaseModel, ContestMixin):
             ),
             #  CRITICAL FIX: Explicitly add scoring_parameters
             "scoring_parameters": scoring_params,
+            # Automated scoring settings
+            "automated_settings": self.get_automated_settings(),
             # Computed fields
             "submission_count": self.get_submission_count(),
             "status": self.get_status(),

--- a/backend/app/models/contest_mixin.py
+++ b/backend/app/models/contest_mixin.py
@@ -182,8 +182,6 @@ class ContestMixin:
                     "enabled": true,
                     "eligibility": {
                         "min_edits": 100,
-                        "min_bytes": 5000,
-                        "min_incoming_links": 2,
                         "min_outgoing_links": 3
                     },
                     "evaluation": {

--- a/backend/app/models/contest_mixin.py
+++ b/backend/app/models/contest_mixin.py
@@ -169,6 +169,62 @@ class ContestMixin:
 
 
     # ------------------------------------------------------------------------
+    # AUTOMATED SETTINGS MANAGEMENT (JSON Dictionary Storage)
+    # ------------------------------------------------------------------------
+
+    def set_automated_settings(self, settings):
+        """
+        Set automated scoring settings configuration
+
+        Args:
+            settings: Dict or None containing automated scoring configuration
+                {
+                    "enabled": true,
+                    "eligibility": {
+                        "min_edits": 100,
+                        "min_bytes": 5000,
+                        "min_incoming_links": 2,
+                        "min_outgoing_links": 3
+                    },
+                    "evaluation": {
+                        "points_per_accepted": 10,
+                        "points_per_byte": 0.001,
+                        "points_per_incoming_link": 2,
+                        "points_per_outgoing_link": 1,
+                        "points_per_category": 1,
+                        "points_per_new_reference": 3,
+                        "points_per_reused_reference": 1,
+                        "points_per_infobox": 5,
+                        "points_per_image": 2
+                    }
+                }
+        """
+        if settings is None:
+            self.automated_settings = None
+        elif isinstance(settings, dict):
+            # Store as JSON string
+            self.automated_settings = json.dumps(settings)
+        else:
+            self.automated_settings = None
+
+
+    def get_automated_settings(self):
+        """
+        Get automated scoring settings configuration
+
+        Returns:
+            dict or None: Automated scoring settings configuration
+        """
+        if not self.automated_settings:
+            return None
+        try:
+            # Parse JSON string back to dictionary
+            return json.loads(self.automated_settings)
+        except json.JSONDecodeError:
+            return None
+
+
+    # ------------------------------------------------------------------------
     # ORGANIZERS MANAGEMENT (Comma-Separated Storage)
     # ------------------------------------------------------------------------
 

--- a/backend/app/routes/contest_routes.py
+++ b/backend/app/routes/contest_routes.py
@@ -743,6 +743,63 @@ def create_contest():
         scoring_parameters = None
 
     # -----------------------------------------------------------------------
+    # Validate Automated Settings (Optional)
+    # -----------------------------------------------------------------------
+
+    automated_settings = data.get("automated_settings")
+
+    if automated_settings:
+        if not isinstance(automated_settings, dict):
+            return jsonify({"error": "Automated settings must be an object"}), 400
+
+        # Validate automated scoring structure if enabled
+        if automated_settings.get("enabled"):
+            current_app.logger.info(f"[AUTOMATED CREATE] Automated scoring enabled")
+
+            # Validate eligibility section
+            eligibility = automated_settings.get("eligibility", {})
+            if not isinstance(eligibility, dict):
+                eligibility = {}
+
+            # Validate evaluation section
+            evaluation = automated_settings.get("evaluation", {})
+            if not isinstance(evaluation, dict):
+                evaluation = {}
+
+            # Validate numeric values in eligibility
+            for field in ["min_edits", "min_bytes", "min_incoming_links", "min_outgoing_links"]:
+                value = eligibility.get(field)
+                if value is not None:
+                    try:
+                        eligibility[field] = int(value)
+                        if eligibility[field] < 0:
+                            return jsonify({"error": f"{field} must be non-negative"}), 400
+                    except (ValueError, TypeError):
+                        return jsonify({"error": f"{field} must be a valid integer"}), 400
+
+            # Validate numeric values in evaluation
+            for field in ["points_per_accepted", "points_per_byte", "points_per_incoming_link",
+                          "points_per_outgoing_link", "points_per_category", "points_per_new_reference",
+                          "points_per_reused_reference", "points_per_infobox", "points_per_image"]:
+                value = evaluation.get(field)
+                if value is not None:
+                    try:
+                        evaluation[field] = float(value)
+                        if evaluation[field] < 0:
+                            return jsonify({"error": f"{field} must be non-negative"}), 400
+                    except (ValueError, TypeError):
+                        return jsonify({"error": f"{field} must be a valid number"}), 400
+
+            # Update with validated values
+            automated_settings["eligibility"] = eligibility
+            automated_settings["evaluation"] = evaluation
+
+            # When automated mode is enabled, scoring_parameters should be null
+            scoring_parameters = None
+    else:
+        automated_settings = None
+
+    # -----------------------------------------------------------------------
     # Create Contest
     # -----------------------------------------------------------------------
 
@@ -810,6 +867,7 @@ def create_contest():
             template_link=template_link,
             outreach_dashboard_url=outreach_dashboard_url,
             scoring_parameters=scoring_parameters,
+            automated_settings=automated_settings,
             organizers=additional_organizers,
             min_reference_count=min_reference_count,
         )
@@ -1198,6 +1256,62 @@ def update_contest(contest_id):
                     contest.set_scoring_parameters(sp)
                 except ValueError as ve:
                     return jsonify({"error": str(ve)}), 400
+
+        # --- Automated Settings (Automated Scoring Mode) ---
+        if "automated_settings" in data:
+            as_settings = data.get("automated_settings")
+            
+            # Accept explicit null to disable automated settings
+            if as_settings is None:
+                contest.set_automated_settings(None)
+            elif not isinstance(as_settings, dict):
+                return jsonify({"error": "automated_settings must be an object"}), 400
+            else:
+                # Validate automated scoring structure if enabled
+                if as_settings.get("enabled"):
+                    # Validate eligibility section
+                    eligibility = as_settings.get("eligibility", {})
+                    if not isinstance(eligibility, dict):
+                        eligibility = {}
+                    
+                    # Validate evaluation section
+                    evaluation = as_settings.get("evaluation", {})
+                    if not isinstance(evaluation, dict):
+                        evaluation = {}
+                    
+                    # Validate numeric values in eligibility
+                    for field in ["min_edits", "min_bytes", "min_incoming_links", "min_outgoing_links"]:
+                        value = eligibility.get(field)
+                        if value is not None:
+                            try:
+                                eligibility[field] = int(value)
+                                if eligibility[field] < 0:
+                                    return jsonify({"error": f"{field} must be non-negative"}), 400
+                            except (ValueError, TypeError):
+                                return jsonify({"error": f"{field} must be a valid integer"}), 400
+                    
+                    # Validate numeric values in evaluation
+                    for field in ["points_per_accepted", "points_per_byte", "points_per_incoming_link",
+                                  "points_per_outgoing_link", "points_per_category", "points_per_new_reference",
+                                  "points_per_reused_reference", "points_per_infobox", "points_per_image"]:
+                        value = evaluation.get(field)
+                        if value is not None:
+                            try:
+                                evaluation[field] = float(value)
+                                if evaluation[field] < 0:
+                                    return jsonify({"error": f"{field} must be non-negative"}), 400
+                            except (ValueError, TypeError):
+                                return jsonify({"error": f"{field} must be a valid number"}), 400
+                    
+                    # Update with validated values
+                    as_settings["eligibility"] = eligibility
+                    as_settings["evaluation"] = evaluation
+                    
+                    # When automated mode is enabled, disable multi-parameter scoring
+                    contest.set_scoring_parameters(None)
+                
+                # Persist validated automated settings
+                contest.set_automated_settings(as_settings)
 
         # --- Organizers ---
         if "organizers" in data:

--- a/backend/app/routes/contest_routes.py
+++ b/backend/app/routes/contest_routes.py
@@ -767,7 +767,7 @@ def create_contest():
                 evaluation = {}
 
             # Validate numeric values in eligibility
-            for field in ["min_edits", "min_bytes", "min_incoming_links", "min_outgoing_links"]:
+            for field in ["min_edits", "min_outgoing_links"]:
                 value = eligibility.get(field)
                 if value is not None:
                     try:
@@ -1280,7 +1280,7 @@ def update_contest(contest_id):
                         evaluation = {}
                     
                     # Validate numeric values in eligibility
-                    for field in ["min_edits", "min_bytes", "min_incoming_links", "min_outgoing_links"]:
+                    for field in ["min_edits", "min_outgoing_links"]:
                         value = eligibility.get(field)
                         if value is not None:
                             try:


### PR DESCRIPTION
Add database schema for automated scoring mode.
- New automated_settings JSON column on contests table for storing eligibility criteria and evaluation point configuration
- Alembic migration to add the column
