### PR TITLE
feat: add automated scoring mode UI in contest creation and editing

### DIFF
--- a/frontend/src/components/CreateContestModal.vue
+++ b/frontend/src/components/CreateContestModal.vue
@@ -107,34 +107,48 @@ required
                 <!-- Radio Button Selection -->
                 <div class="row mb-4">
                   <!-- Simple Scoring Option -->
-                  <div class="col-md-6">
-                    <label :class="{ 'active': !enableMultiParameterScoring }">
+                  <div class="col-md-4">
+                    <label :class="{ 'active': scoringMode === 'simple' }">
                       <input type="radio"
 name="scoringMode"
-:value="false"
-v-model="enableMultiParameterScoring"
+value="simple"
+v-model="scoringMode"
                         :disabled="loading" />
                       <h6>Simple Scoring</h6>
                     </label>
                   </div>
 
                   <!-- Multi-Parameter Scoring Option -->
-                  <div class="col-md-6">
-                    <label :class="{ 'active': enableMultiParameterScoring }">
+                  <div class="col-md-4">
+                    <label :class="{ 'active': scoringMode === 'multi_parameter' }">
                       <input type="radio"
 name="scoringMode"
-:value="true"
-v-model="enableMultiParameterScoring"
+value="multi_parameter"
+v-model="scoringMode"
                         :disabled="loading" />
                       <div>
                         <h6>Multi-Parameter Scoring</h6>
                       </div>
                     </label>
                   </div>
+
+                  <!-- Automated Scoring Option -->
+                  <div class="col-md-4">
+                    <label :class="{ 'active': scoringMode === 'automated' }">
+                      <input type="radio"
+name="scoringMode"
+value="automated"
+v-model="scoringMode"
+                        :disabled="loading" />
+                      <div>
+                        <h6>Automated Scoring</h6>
+                      </div>
+                    </label>
+                  </div>
                 </div>
 
-                <!--  SIMPLE SCORING CONTENT - Shown when enableMultiParameterScoring is FALSE -->
-                <div v-if="!enableMultiParameterScoring">
+                <!--  SIMPLE SCORING CONTENT - Shown when scoringMode is 'simple' -->
+                <div v-if="scoringMode === 'simple'">
                   <div class="alert alert-success">
                     <i class="fas fa-check-circle me-2"></i>
                     <strong>Simple Scoring Enabled:</strong> Jury will assign a single score for each submission.
@@ -171,8 +185,8 @@ required
                   </div>
                 </div>
 
-                <!--  MULTI-PARAMETER SCORING CONTENT - Shown when enableMultiParameterScoring is TRUE -->
-                <div v-else>
+                <!--  MULTI-PARAMETER SCORING CONTENT - Shown when scoringMode is 'multi_parameter' -->
+                <div v-else-if="scoringMode === 'multi_parameter'">
                   <div class="alert alert-primary">
                     <i class="fas fa-star me-2"></i>
                     <strong>Multi-Parameter Scoring Enabled:</strong> Jury will score submissions on multiple parameters
@@ -288,6 +302,153 @@ class="btn btn-sm btn-outline-secondary"
 @click="loadDefaultParameters"
                     :disabled="loading">
                     <i class="fas fa-redo me-1"></i>Load Default Parameters
+                  </button>
+                </div>
+
+                <!--  AUTOMATED SCORING CONTENT - Shown when scoringMode is 'automated' -->
+                <div v-else-if="scoringMode === 'automated'">
+                  <div class="alert alert-info">
+                    <i class="fas fa-robot me-2"></i>
+                    <strong>Automated Scoring Enabled:</strong> Articles will be automatically evaluated and scored
+                    based on eligibility criteria and article metrics.
+                  </div>
+
+                  <!-- Eligibility Criteria Section -->
+                  <div class="mb-4">
+                    <h6 class="mb-3"><i class="fas fa-filter me-2"></i>Eligibility Criteria</h6>
+                    <p class="text-muted small mb-3">
+                      Articles must meet these minimum requirements to be accepted automatically.
+                    </p>
+                    <div class="row">
+                      <div class="col-md-6 mb-3">
+                        <label class="form-label">Minimum Edits</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.eligibility.min_edits"
+min="0"
+placeholder="e.g., 100"
+                          :disabled="loading" />
+                        <small class="form-text text-muted">Minimum edit count required</small>
+                      </div>
+                      <div class="col-md-6 mb-3">
+                        <label class="form-label">Minimum Outgoing Links</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.eligibility.min_outgoing_links"
+min="0"
+placeholder="e.g., 3"
+                          :disabled="loading" />
+                        <small class="form-text text-muted">Links from this article to other articles</small>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Evaluation Criteria Section -->
+                  <div class="mb-4">
+                    <h6 class="mb-3"><i class="fas fa-calculator me-2"></i>Evaluation Criteria (Points)</h6>
+                    <p class="text-muted small mb-3">
+                      Points awarded for each metric when calculating the final score.
+                    </p>
+                    <div class="row">
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Accepted</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_accepted"
+min="0"
+step="0.01"
+placeholder="e.g., 10"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Byte</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_byte"
+min="0"
+step="0.0001"
+placeholder="e.g., 0.001"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Incoming Link</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_incoming_link"
+min="0"
+step="0.01"
+placeholder="e.g., 2"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Outgoing Link</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_outgoing_link"
+min="0"
+step="0.01"
+placeholder="e.g., 1"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Category</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_category"
+min="0"
+step="0.01"
+placeholder="e.g., 1"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per New Reference</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_new_reference"
+min="0"
+step="0.01"
+placeholder="e.g., 3"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Reused Reference</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_reused_reference"
+min="0"
+step="0.01"
+placeholder="e.g., 1"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Infobox</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_infobox"
+min="0"
+step="0.01"
+placeholder="e.g., 5"
+                          :disabled="loading" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Image</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_image"
+min="0"
+step="0.01"
+placeholder="e.g., 2"
+                          :disabled="loading" />
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Reset to default automated settings -->
+                  <button type="button"
+class="btn btn-sm btn-outline-secondary"
+@click="loadDefaultAutomatedSettings"
+                    :disabled="loading">
+                    <i class="fas fa-redo me-1"></i>Load Default Settings
                   </button>
                 </div>
               </div>
@@ -553,13 +714,33 @@ export default {
     const jurySearchQuery = ref('')
     const jurySearchResults = ref([])
     let searchTimeout = null
-    const enableMultiParameterScoring = ref(false)
+    const scoringMode = ref('simple') // 'simple', 'multi_parameter', or 'automated'
     const maxScore = ref(10)
     const minScore = ref(0)
     const selectedOrganizers = ref([])
     const organizerSearchQuery = ref('')
     const organizerSearchResults = ref([])
     let organizerSearchTimeout = null
+
+    // Automated scoring settings
+    const automatedSettings = reactive({
+      enabled: true,
+      eligibility: {
+        min_edits: 100,
+        min_outgoing_links: 3
+      },
+      evaluation: {
+        points_per_accepted: 10,
+        points_per_byte: 0.001,
+        points_per_incoming_link: 2,
+        points_per_outgoing_link: 1,
+        points_per_category: 1,
+        points_per_new_reference: 3,
+        points_per_reused_reference: 1,
+        points_per_infobox: 5,
+        points_per_image: 2
+      }
+    })
 
     // Default scoring parameters with weights
     const scoringParameters = ref([
@@ -605,11 +786,30 @@ export default {
       ]
     }
 
-    // Watch for scoring mode changes
-    watch(enableMultiParameterScoring, (newValue) => {
-      console.log(`[SCORING] Mode changed to: ${newValue ? 'Multi-Parameter' : 'Simple'}`)
+    // Reset to default automated settings
+    const loadDefaultAutomatedSettings = () => {
+      automatedSettings.eligibility = {
+        min_edits: 100,
+        min_outgoing_links: 3
+      }
+      automatedSettings.evaluation = {
+        points_per_accepted: 10,
+        points_per_byte: 0.001,
+        points_per_incoming_link: 2,
+        points_per_outgoing_link: 1,
+        points_per_category: 1,
+        points_per_new_reference: 3,
+        points_per_reused_reference: 1,
+        points_per_infobox: 5,
+        points_per_image: 2
+      }
+    }
 
-      if (!newValue) {
+    // Watch for scoring mode changes
+    watch(scoringMode, (newValue) => {
+      console.log(`[SCORING] Mode changed to: ${newValue}`)
+
+      if (newValue === 'simple') {
         // Switching to simple - ensure simple scoring values are set
         if (!formData.marks_setting_accepted) {
           formData.marks_setting_accepted = 10
@@ -617,10 +817,15 @@ export default {
         if (!formData.marks_setting_rejected && formData.marks_setting_rejected !== 0) {
           formData.marks_setting_rejected = 0
         }
-      } else {
+      } else if (newValue === 'multi_parameter') {
         // Switching to multi - ensure parameters are initialized
         if (scoringParameters.value.length === 0) {
           loadDefaultParameters()
+        }
+      } else if (newValue === 'automated') {
+        // Switching to automated - ensure settings are initialized
+        if (!automatedSettings.eligibility || !automatedSettings.evaluation) {
+          loadDefaultAutomatedSettings()
         }
       }
     })
@@ -951,7 +1156,7 @@ export default {
       }
 
       // Scoring-specific validation
-      if (enableMultiParameterScoring.value) {
+      if (scoringMode.value === 'multi_parameter') {
         if (totalWeight.value !== 100) {
           showAlert(
             'Multi-Parameter Scoring requires weights to sum to 100%. ' +
@@ -967,13 +1172,14 @@ export default {
           showAlert('All scoring parameters must have names', 'warning')
           return
         }
-      } else {
+      } else if (scoringMode.value === 'simple') {
         // Simple scoring validation
         if (formData.marks_setting_accepted < 0) {
           showAlert('Points for accepted submissions must be non-negative', 'warning')
           return
         }
       }
+      // Automated mode validation - eligibility and evaluation values are optional with defaults
 
       // Set loading state to prevent multiple submissions
       loading.value = true
@@ -981,12 +1187,13 @@ export default {
       try {
         // Build scoring parameters payload
         let scoringParametersPayload = null
+        let automatedSettingsPayload = null
 
-        console.log('[CREATE] enableMultiParameterScoring:', enableMultiParameterScoring.value)
+        console.log('[CREATE] scoringMode:', scoringMode.value)
         console.log('[CREATE] scoringParameters:', scoringParameters.value)
         console.log('[CREATE] totalWeight:', totalWeight.value)
 
-        if (enableMultiParameterScoring.value) {
+        if (scoringMode.value === 'multi_parameter') {
           scoringParametersPayload = {
             enabled: true,
             max_score: Number(maxScore.value),
@@ -999,7 +1206,30 @@ export default {
           }
 
           console.log('[CREATE] Built scoring payload:', JSON.stringify(scoringParametersPayload, null, 2))
+        } else if (scoringMode.value === 'automated') {
+          // Build automated settings payload
+          automatedSettingsPayload = {
+            enabled: true,
+            eligibility: {
+              min_edits: Number(automatedSettings.eligibility.min_edits) || 0,
+              min_outgoing_links: Number(automatedSettings.eligibility.min_outgoing_links) || 0
+            },
+            evaluation: {
+              points_per_accepted: Number(automatedSettings.evaluation.points_per_accepted) || 0,
+              points_per_byte: Number(automatedSettings.evaluation.points_per_byte) || 0,
+              points_per_incoming_link: Number(automatedSettings.evaluation.points_per_incoming_link) || 0,
+              points_per_outgoing_link: Number(automatedSettings.evaluation.points_per_outgoing_link) || 0,
+              points_per_category: Number(automatedSettings.evaluation.points_per_category) || 0,
+              points_per_new_reference: Number(automatedSettings.evaluation.points_per_new_reference) || 0,
+              points_per_reused_reference: Number(automatedSettings.evaluation.points_per_reused_reference) || 0,
+              points_per_infobox: Number(automatedSettings.evaluation.points_per_infobox) || 0,
+              points_per_image: Number(automatedSettings.evaluation.points_per_image) || 0
+            }
+          }
+
+          console.log('[CREATE] Built automated settings payload:', JSON.stringify(automatedSettingsPayload, null, 2))
         } else {
+          // Simple scoring
           scoringParametersPayload = {
             enabled: false,
             max_score: Number(formData.marks_setting_accepted),
@@ -1041,6 +1271,8 @@ export default {
           // Outreach Dashboard URL (optional): trim or set to null if empty
           outreach_dashboard_url: outreachUrlValue,
           scoring_parameters: scoringParametersPayload,
+          // Automated settings (only for automated mode)
+          automated_settings: automatedSettingsPayload,
           min_reference_count: formData.min_reference_count || 0
         }
 
@@ -1102,10 +1334,11 @@ export default {
       nextWeek.setDate(nextWeek.getDate() + 7)
       formData.start_date = tomorrow.toISOString().split('T')[0]
       formData.end_date = nextWeek.toISOString().split('T')[0]
-      enableMultiParameterScoring.value = false
+      scoringMode.value = 'simple'
       maxScore.value = 10
       minScore.value = 0
       loadDefaultParameters()
+      loadDefaultAutomatedSettings()
     }
 
     return {
@@ -1129,7 +1362,7 @@ export default {
       removeCategory,
       handleSubmit,
       store,
-      enableMultiParameterScoring,
+      scoringMode,
       maxScore,
       minScore,
       scoringParameters,
@@ -1137,7 +1370,9 @@ export default {
       weightTotalClass,
       addParameter,
       removeParameter,
-      loadDefaultParameters
+      loadDefaultParameters,
+      automatedSettings,
+      loadDefaultAutomatedSettings
     }
   }
 }
@@ -1609,5 +1844,52 @@ input[type="date"].form-control {
 .badge.bg-secondary {
   background-color: #6c757d !important;
   color: white;
+}
+
+/* Automated Scoring Section Styles */
+.alert-info {
+  background-color: rgba(13, 202, 240, 0.15);
+  border-color: rgba(13, 202, 240, 0.3);
+  color: var(--wiki-text);
+}
+
+[data-theme="dark"] .alert-info {
+  background-color: rgba(13, 202, 240, 0.2);
+  border-color: rgba(13, 202, 240, 0.4);
+}
+
+/* Scoring mode radio button labels */
+.card-body label {
+  display: block;
+  padding: 1rem;
+  border: 2px solid var(--wiki-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.card-body label:hover {
+  border-color: var(--wiki-primary);
+  background-color: var(--wiki-hover-bg);
+}
+
+.card-body label.active {
+  border-color: var(--wiki-primary);
+  background-color: rgba(0, 102, 153, 0.1);
+}
+
+[data-theme="dark"] .card-body label.active {
+  background-color: rgba(93, 184, 230, 0.15);
+}
+
+.card-body label input[type="radio"] {
+  margin-bottom: 0.5rem;
+}
+
+.card-body label h6 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--wiki-text);
 }
 </style>

--- a/frontend/src/views/ContestView.vue
+++ b/frontend/src/views/ContestView.vue
@@ -457,8 +457,80 @@ aria-labelledby="outreach-tab">
             </div>
 
             <div class="scoring-content">
+              <!-- Automated Scoring Display -->
+              <div v-if="contest.automated_settings?.enabled === true">
+                <div class="automated-header">
+                  <i class="fas fa-robot me-2"></i>
+                  <strong>Automated Scoring</strong>
+                  <span class="badge bg-info ms-2">Auto-evaluated</span>
+                </div>
+
+                <!-- Eligibility Criteria -->
+                <div class="automated-section">
+                  <h6 class="section-title"><i class="fas fa-filter me-2"></i>Eligibility Criteria</h6>
+                  <div class="criteria-grid">
+                    <div class="criteria-item">
+                      <span class="criteria-label">Min Edits</span>
+                      <span class="criteria-value">{{ contest.automated_settings.eligibility?.min_edits ?? 0 }}</span>
+                    </div>
+                    <div class="criteria-item">
+                      <span class="criteria-label">Min Outgoing Links</span>
+                      <span class="criteria-value">{{ contest.automated_settings.eligibility?.min_outgoing_links ?? 0 }}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Evaluation Points -->
+                <div class="automated-section">
+                  <h6 class="section-title"><i class="fas fa-calculator me-2"></i>Evaluation Points</h6>
+                  <div class="points-grid">
+                    <div class="point-chip">
+                      <span class="chip-label">Accepted</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_accepted ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">Per Byte</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_byte ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">Incoming Link</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_incoming_link ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">Outgoing Link</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_outgoing_link ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">Category</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_category ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">New Ref</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_new_reference ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">Reused Ref</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_reused_reference ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">Infobox</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_infobox ?? 0 }}</span>
+                    </div>
+                    <div class="point-chip">
+                      <span class="chip-label">Image</span>
+                      <span class="chip-value">{{ contest.automated_settings.evaluation?.points_per_image ?? 0 }}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="info-note">
+                  <i class="fas fa-info-circle"></i>
+                  <span>Articles are automatically scored based on metrics and eligibility criteria</span>
+                </div>
+              </div>
+
               <!-- Multi-Parameter Scoring Display -->
-              <div v-if="contest.scoring_parameters?.enabled === true">
+              <div v-else-if="contest.scoring_parameters?.enabled === true">
                 <div class="scoring-meta">
                   <span class="max-points">Accepted points: {{ contest.scoring_parameters.max_score }}</span>
                   <span class="max-points">Rejected points: {{ contest.scoring_parameters.min_score }}</span>
@@ -3198,6 +3270,105 @@ export default {
 
 .info-note i {
   font-size: 0.9375em;
+}
+
+/* Automated Scoring Display Styles */
+.automated-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid var(--wiki-border);
+  font-size: 1.125rem;
+  color: var(--wiki-primary);
+}
+
+.automated-section {
+  margin-bottom: 1.25rem;
+}
+
+.automated-section .section-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--wiki-text);
+  margin-bottom: 0.75rem;
+}
+
+.criteria-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.criteria-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.625rem 0.875rem;
+  background: #f3f4f6;
+  border-radius: 6px;
+  border: 1px solid #e5e7eb;
+}
+
+[data-theme="dark"] .criteria-item {
+  background: #1f1f1f;
+  border-color: #404040;
+}
+
+.criteria-label {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+[data-theme="dark"] .criteria-label {
+  color: #9ca3af;
+}
+
+.criteria-value {
+  font-weight: 600;
+  color: var(--wiki-primary);
+  font-size: 0.9375rem;
+}
+
+.points-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.point-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem 0.625rem;
+  background: rgba(13, 202, 240, 0.1);
+  border-radius: 6px;
+  border: 1px solid rgba(13, 202, 240, 0.3);
+}
+
+[data-theme="dark"] .point-chip {
+  background: rgba(13, 202, 240, 0.15);
+  border-color: rgba(13, 202, 240, 0.4);
+}
+
+.chip-label {
+  font-size: 0.75rem;
+  color: #6b7280;
+  text-align: center;
+}
+
+[data-theme="dark"] .chip-label {
+  color: #9ca3af;
+}
+
+.chip-value {
+  font-weight: 600;
+  color: #0dcaf0;
+  font-size: 0.9375rem;
+}
+
+[data-theme="dark"] .chip-value {
+  color: #5bc8e6;
 }
 
 .points-row {

--- a/frontend/src/views/ContestView.vue
+++ b/frontend/src/views/ContestView.vue
@@ -997,7 +997,10 @@ style="cursor: pointer;"
                   </div>
                   <div class="lock-banner-content">
                     <div class="scoring-mode-badge">
-                      <span v-if="contestScoringMode === 'multi_parameter'" class="badge-mode multi">
+                      <span v-if="contestScoringMode === 'automated'" class="badge-mode automated">
+                        <i class="fas fa-robot me-2"></i>Automated Scoring
+                      </span>
+                      <span v-else-if="contestScoringMode === 'multi_parameter'" class="badge-mode multi">
                         <i class="fas fa-star me-2"></i>Multi-Parameter Scoring
                       </span>
                       <span v-else class="badge-mode simple">
@@ -1018,6 +1021,12 @@ style="cursor: pointer;"
                   <i class="fas fa-info-circle me-2"></i>
                   <strong>What you can edit:</strong>
                   <ul class="mb-0 mt-2">
+                    <li v-if="contestScoringMode === 'automated'">
+                      Eligibility criteria values
+                    </li>
+                    <li v-if="contestScoringMode === 'automated'">
+                      Evaluation points values
+                    </li>
                     <li v-if="contestScoringMode === 'multi_parameter'">
                       Maximum and minimum score values
                     </li>
@@ -1133,7 +1142,7 @@ class="btn btn-sm btn-outline-danger"
                 </div>
 
                 <!-- Simple Scoring Locked Editing -->
-                <div v-else>
+                <div v-else-if="contestScoringMode === 'simple'">
                   <div class="row">
                     <div class="col-md-6 mb-3">
                       <label class="form-label">Points for Accepted Submissions *</label>
@@ -1152,6 +1161,109 @@ v-model.number="editForm.marks_setting_rejected"
 min="0"
                         required />
                       <small class="text-muted">Points for rejected submissions</small>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Automated Scoring Locked Editing -->
+                <div v-else-if="contestScoringMode === 'automated'">
+                  <!-- Eligibility Criteria -->
+                  <div class="mb-4">
+                    <h6 class="mb-3"><i class="fas fa-filter me-2"></i>Eligibility Criteria</h6>
+                    <div class="row">
+                      <div class="col-md-6 mb-3">
+                        <label class="form-label">Minimum Edits</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.eligibility.min_edits"
+min="0" />
+                      </div>
+                      <div class="col-md-6 mb-3">
+                        <label class="form-label">Minimum Outgoing Links</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.eligibility.min_outgoing_links"
+min="0" />
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Evaluation Criteria -->
+                  <div class="mb-4">
+                    <h6 class="mb-3"><i class="fas fa-calculator me-2"></i>Evaluation Criteria (Points)</h6>
+                    <div class="row">
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Accepted</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_accepted"
+min="0"
+step="0.01" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Byte</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_byte"
+min="0"
+step="0.0001" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Incoming Link</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_incoming_link"
+min="0"
+step="0.01" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Outgoing Link</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_outgoing_link"
+min="0"
+step="0.01" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Category</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_category"
+min="0"
+step="0.01" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per New Reference</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_new_reference"
+min="0"
+step="0.01" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Reused Reference</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_reused_reference"
+min="0"
+step="0.01" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Infobox</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_infobox"
+min="0"
+step="0.01" />
+                      </div>
+                      <div class="col-md-4 mb-3">
+                        <label class="form-label">Points per Image</label>
+                        <input type="number"
+class="form-control"
+v-model.number="automatedSettings.evaluation.points_per_image"
+min="0"
+step="0.01" />
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1481,9 +1593,29 @@ export default {
       { name: 'Neutrality', weight: 20, description: 'Unbiased writing' },
       { name: 'Formatting', weight: 10, description: 'Presentation & formatting' }
     ])
-    const contestScoringMode = ref('simple')
+    const contestScoringMode = ref('simple') // 'simple', 'multi_parameter', or 'automated'
     const scoringModeLocked = ref(false)
     const reviewedSubmissionsCount = ref(0)
+
+    // Automated scoring settings for edit modal
+    const automatedSettings = reactive({
+      enabled: true,
+      eligibility: {
+        min_edits: 100,
+        min_outgoing_links: 3
+      },
+      evaluation: {
+        points_per_accepted: 10,
+        points_per_byte: 0.001,
+        points_per_incoming_link: 2,
+        points_per_outgoing_link: 1,
+        points_per_category: 1,
+        points_per_new_reference: 3,
+        points_per_reused_reference: 1,
+        points_per_infobox: 5,
+        points_per_image: 2
+      }
+    })
 
     // Calculate total weight of all parameters
     const totalWeight = computed(() => {
@@ -1519,6 +1651,25 @@ export default {
         { name: 'Neutrality', weight: 20, description: 'Unbiased writing' },
         { name: 'Formatting', weight: 10, description: 'Presentation & formatting' }
       ]
+    }
+
+    // Reset to default automated settings
+    const loadDefaultAutomatedSettings = () => {
+      automatedSettings.eligibility = {
+        min_edits: 100,
+        min_outgoing_links: 3
+      }
+      automatedSettings.evaluation = {
+        points_per_accepted: 10,
+        points_per_byte: 0.001,
+        points_per_incoming_link: 2,
+        points_per_outgoing_link: 1,
+        points_per_category: 1,
+        points_per_new_reference: 3,
+        points_per_reused_reference: 1,
+        points_per_infobox: 5,
+        points_per_image: 2
+      }
     }
 
     // Track current submission for preview modal
@@ -2229,7 +2380,10 @@ export default {
       scoringModeLocked.value = reviewedSubmissions.length > 0
 
       // This determines what the contest is CURRENTLY using
-      if (contest.value.scoring_parameters?.enabled === true) {
+      if (contest.value.automated_settings?.enabled === true) {
+        contestScoringMode.value = 'automated'
+        console.log('[EDIT MODAL] Current scoring mode: AUTOMATED')
+      } else if (contest.value.scoring_parameters?.enabled === true) {
         contestScoringMode.value = 'multi_parameter'
         console.log('[EDIT MODAL] Current scoring mode: MULTI-PARAMETER')
       } else {
@@ -2237,7 +2391,37 @@ export default {
         console.log('[EDIT MODAL] Current scoring mode: SIMPLE')
       }
 
-      if (contestScoringMode.value === 'multi_parameter') {
+      if (contestScoringMode.value === 'automated') {
+        // Contest is using automated scoring
+        enableMultiParameterScoring.value = false
+
+        // Load automated settings
+        if (contest.value.automated_settings) {
+          automatedSettings.eligibility = {
+            min_edits: Number(contest.value.automated_settings.eligibility?.min_edits ?? 100),
+            min_outgoing_links: Number(contest.value.automated_settings.eligibility?.min_outgoing_links ?? 3)
+          }
+          automatedSettings.evaluation = {
+            points_per_accepted: Number(contest.value.automated_settings.evaluation?.points_per_accepted ?? 10),
+            points_per_byte: Number(contest.value.automated_settings.evaluation?.points_per_byte ?? 0.001),
+            points_per_incoming_link: Number(contest.value.automated_settings.evaluation?.points_per_incoming_link ?? 2),
+            points_per_outgoing_link: Number(contest.value.automated_settings.evaluation?.points_per_outgoing_link ?? 1),
+            points_per_category: Number(contest.value.automated_settings.evaluation?.points_per_category ?? 1),
+            points_per_new_reference: Number(contest.value.automated_settings.evaluation?.points_per_new_reference ?? 3),
+            points_per_reused_reference: Number(contest.value.automated_settings.evaluation?.points_per_reused_reference ?? 1),
+            points_per_infobox: Number(contest.value.automated_settings.evaluation?.points_per_infobox ?? 5),
+            points_per_image: Number(contest.value.automated_settings.evaluation?.points_per_image ?? 2)
+          }
+        } else {
+          loadDefaultAutomatedSettings()
+        }
+
+        editForm.automated_settings = {
+          enabled: true,
+          eligibility: { ...automatedSettings.eligibility },
+          evaluation: { ...automatedSettings.evaluation }
+        }
+      } else if (contestScoringMode.value === 'multi_parameter') {
         // Contest is using multi-parameter scoring
         enableMultiParameterScoring.value = true
 
@@ -2309,8 +2493,30 @@ export default {
         }
 
         let scoringParametersPayload = null
+        let automatedSettingsPayload = null
 
-        if (enableMultiParameterScoring.value) {
+        if (contestScoringMode.value === 'automated') {
+          // Automated scoring is enabled
+          automatedSettingsPayload = {
+            enabled: true,
+            eligibility: {
+              min_edits: Number(automatedSettings.eligibility.min_edits) || 0,
+              min_outgoing_links: Number(automatedSettings.eligibility.min_outgoing_links) || 0
+            },
+            evaluation: {
+              points_per_accepted: Number(automatedSettings.evaluation.points_per_accepted) || 0,
+              points_per_byte: Number(automatedSettings.evaluation.points_per_byte) || 0,
+              points_per_incoming_link: Number(automatedSettings.evaluation.points_per_incoming_link) || 0,
+              points_per_outgoing_link: Number(automatedSettings.evaluation.points_per_outgoing_link) || 0,
+              points_per_category: Number(automatedSettings.evaluation.points_per_category) || 0,
+              points_per_new_reference: Number(automatedSettings.evaluation.points_per_new_reference) || 0,
+              points_per_reused_reference: Number(automatedSettings.evaluation.points_per_reused_reference) || 0,
+              points_per_infobox: Number(automatedSettings.evaluation.points_per_infobox) || 0,
+              points_per_image: Number(automatedSettings.evaluation.points_per_image) || 0
+            }
+          }
+          scoringParametersPayload = null
+        } else if (enableMultiParameterScoring.value) {
           // Multi-parameter scoring is enabled (either locked or unlocked)
 
           // Validate weights sum to 100
@@ -2373,7 +2579,8 @@ export default {
           outreach_dashboard_url: outreachUrlValue,
           marks_setting_accepted: Number(editForm.marks_setting_accepted),
           marks_setting_rejected: Number(editForm.marks_setting_rejected),
-          scoring_parameters: scoringParametersPayload
+          scoring_parameters: scoringParametersPayload,
+          automated_settings: automatedSettingsPayload
         }
         await api.put(`/contest/${contest.value.id}`, payload)
 
@@ -2490,7 +2697,9 @@ export default {
       savingContest,
       scoringModeLocked,
       reviewedSubmissionsCount,
-      contestScoringMode
+      contestScoringMode,
+      automatedSettings,
+      loadDefaultAutomatedSettings
     }
   }
 }


### PR DESCRIPTION
Add frontend support for configuring automated scoring mode.
- New "Automated Scoring" option in contest creation form
- Eligibility criteria settings (minimum edits, minimum outgoing links)
- Evaluation point settings (points per byte, link, reference, image, etc.)
- Automated mode is mutually exclusive with simple/multi-parameter modes
