### PR TITLE
feat: add bulk article import from Wikipedia categories

### DIFF
--- a/backend/app/routes/contest_routes.py
+++ b/backend/app/routes/contest_routes.py
@@ -35,6 +35,7 @@ from app.utils import (
     get_article_infobox_count,
     get_article_incoming_links,
     get_article_outgoing_links,
+    crawl_category_articles,
     MEDIAWIKI_API_TIMEOUT,
 )
 from app.services.outreach_dashboard import (
@@ -2932,4 +2933,129 @@ def reject_contest_request(request_id):
     return jsonify({
         'message': 'Contest request rejected successfully',
         'requestId': contest_request.id
+    }), 200
+
+
+# ------------------------------------------------------------------------
+# CATEGORY CRAWLER ROUTE
+# ------------------------------------------------------------------------
+
+
+@contest_bp.route("/<int:contest_id>/crawl-category", methods=["POST"])
+@require_auth
+@handle_errors
+@validate_json_data(["category_url"])
+def crawl_category_for_contest(contest_id):
+    """
+    Crawl articles from a Wikipedia category and create pending submissions.
+
+    This endpoint is used for automated scoring contests to import articles
+    from a Wikipedia category. Each article is created as a pending submission
+    that can later be evaluated by the automated evaluation engine.
+
+    Args:
+        contest_id: Contest ID to add submissions to
+
+    Expected JSON data:
+        category_url: Full URL to a Wikipedia category page
+        limit: Optional maximum number of articles to import (default: 5000, max: 5000)
+
+    Returns:
+        JSON response with:
+            - message: Success message
+            - total_imported: Number of submissions created
+            - articles: List of imported article titles
+            - skipped: Number of articles skipped (duplicates)
+    """
+    user = request.current_user
+    data = request.get_json()
+
+    # Fetch contest
+    contest = Contest.query.get(contest_id)
+    if not contest:
+        return jsonify({"error": "Contest not found"}), 404
+
+    # Check if contest uses automated scoring
+    scoring_mode = contest.get_scoring_mode()
+    if scoring_mode != "automated":
+        return jsonify({
+            "error": "Category crawling is only available for automated scoring contests"
+        }), 400
+
+    # Permission check: admin, creator, or organizer
+    is_admin = hasattr(user, "is_admin") and callable(getattr(user, "is_admin")) and user.is_admin()
+    is_creator = getattr(user, "username", None) == getattr(contest, "created_by", None)
+    is_organizer = user.username in [o.username for o in contest.organizers] if hasattr(contest, "organizers") else False
+
+    if not (is_admin or is_creator or is_organizer):
+        return jsonify({"error": "You do not have permission to crawl categories for this contest"}), 403
+
+    # Get parameters
+    category_url = data.get("category_url")
+    limit = data.get("limit", 5000)
+
+    # Validate limit
+    try:
+        limit = min(int(limit), 5000)
+    except (ValueError, TypeError):
+        limit = 5000
+
+    # Crawl the category
+    result = crawl_category_articles(category_url, limit=limit)
+
+    if not result:
+        return jsonify({
+            "error": "Failed to crawl category. Please check the category URL."
+        }), 400
+
+    articles = result.get("articles", [])
+    imported = []
+    skipped = 0
+
+    # Get existing article links for this contest to avoid duplicates
+    existing_links = set(
+        s.article_link for s in Submission.query.filter_by(contest_id=contest_id).all()
+    )
+
+    # Create submissions for each article
+    for article in articles:
+        article_url = article.get("url")
+        article_title = article.get("title")
+
+        # Skip if already submitted
+        if article_url in existing_links:
+            skipped += 1
+            continue
+
+        # Create pending submission
+        # For automated contests, we use a system user (user_id of contest creator or first organizer)
+        # The submission will be marked as pending for automated evaluation
+        submission = Submission(
+            user_id=user.id,  # Use current user as the importer
+            contest_id=contest_id,
+            article_title=article_title,
+            article_link=article_url,
+            status="pending",
+        )
+
+        try:
+            submission.save()
+            imported.append(article_title)
+            existing_links.add(article_url)  # Prevent duplicates within this batch
+        except IntegrityError:
+            # Duplicate submission, skip
+            db.session.rollback()
+            skipped += 1
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            current_app.logger.error(f"Error creating submission for {article_title}: {str(e)}")
+            db.session.rollback()
+            skipped += 1
+
+    return jsonify({
+        "message": f"Successfully imported {len(imported)} articles from category",
+        "total_imported": len(imported),
+        "skipped": skipped,
+        "category": result.get("category"),
+        "wiki_base": result.get("wiki_base"),
+        "articles": imported[:100],  # Return first 100 for preview
     }), 200

--- a/backend/app/routes/contest_routes.py
+++ b/backend/app/routes/contest_routes.py
@@ -2948,114 +2948,103 @@ def reject_contest_request(request_id):
 def crawl_category_for_contest(contest_id):
     """
     Crawl articles from a Wikipedia category and create pending submissions.
-
-    This endpoint is used for automated scoring contests to import articles
-    from a Wikipedia category. Each article is created as a pending submission
-    that can later be evaluated by the automated evaluation engine.
-
-    Args:
-        contest_id: Contest ID to add submissions to
-
-    Expected JSON data:
-        category_url: Full URL to a Wikipedia category page
-        limit: Optional maximum number of articles to import (default: 5000, max: 5000)
-
-    Returns:
-        JSON response with:
-            - message: Success message
-            - total_imported: Number of submissions created
-            - articles: List of imported article titles
-            - skipped: Number of articles skipped (duplicates)
     """
-    user = request.current_user
-    data = request.get_json()
-
-    # Fetch contest
-    contest = Contest.query.get(contest_id)
-    if not contest:
-        return jsonify({"error": "Contest not found"}), 404
-
-    # Check if contest uses automated scoring
-    scoring_mode = contest.get_scoring_mode()
-    if scoring_mode != "automated":
-        return jsonify({
-            "error": "Category crawling is only available for automated scoring contests"
-        }), 400
-
-    # Permission check: admin, creator, or organizer
-    is_admin = hasattr(user, "is_admin") and callable(getattr(user, "is_admin")) and user.is_admin()
-    is_creator = getattr(user, "username", None) == getattr(contest, "created_by", None)
-    is_organizer = user.username in [o.username for o in contest.organizers] if hasattr(contest, "organizers") else False
-
-    if not (is_admin or is_creator or is_organizer):
-        return jsonify({"error": "You do not have permission to crawl categories for this contest"}), 403
-
-    # Get parameters
-    category_url = data.get("category_url")
-    limit = data.get("limit", 5000)
-
-    # Validate limit
     try:
-        limit = min(int(limit), 5000)
-    except (ValueError, TypeError):
-        limit = 5000
+        user = request.current_user
+        data = request.get_json()
 
-    # Crawl the category
-    result = crawl_category_articles(category_url, limit=limit)
+        # Fetch contest
+        contest = Contest.query.get(contest_id)
+        if not contest:
+            return jsonify({"error": "Contest not found"}), 404
 
-    if not result:
-        return jsonify({
-            "error": "Failed to crawl category. Please check the category URL."
-        }), 400
+        # Check if contest uses automated scoring
+        try:
+            scoring_mode = contest.get_scoring_mode()
+        except Exception as e:
+            current_app.logger.error(f"Error getting scoring mode: {str(e)}")
+            scoring_mode = "simple"
 
-    articles = result.get("articles", [])
-    imported = []
-    skipped = 0
+        if scoring_mode != "automated":
+            return jsonify({
+                "error": f"Category crawling is only available for automated scoring contests. Current mode: {scoring_mode}"
+            }), 400
 
-    # Get existing article links for this contest to avoid duplicates
-    existing_links = set(
-        s.article_link for s in Submission.query.filter_by(contest_id=contest_id).all()
-    )
+        # Permission check: jury member or superadmin only
+        jury_members = contest.get_jury_members() if hasattr(contest, "get_jury_members") else []
+        is_jury_member = user.username in jury_members if jury_members else False
+        is_superadmin = getattr(user, "role", None) == "superadmin"
 
-    # Create submissions for each article
-    for article in articles:
-        article_url = article.get("url")
-        article_title = article.get("title")
+        if not (is_jury_member or is_superadmin):
+            return jsonify({"error": "You do not have permission to crawl categories for this contest"}), 403
 
-        # Skip if already submitted
-        if article_url in existing_links:
-            skipped += 1
-            continue
+        # Get parameters
+        category_url = data.get("category_url")
+        limit = data.get("limit", 5000)
 
-        # Create pending submission
-        # For automated contests, we use a system user (user_id of contest creator or first organizer)
-        # The submission will be marked as pending for automated evaluation
-        submission = Submission(
-            user_id=user.id,  # Use current user as the importer
-            contest_id=contest_id,
-            article_title=article_title,
-            article_link=article_url,
-            status="pending",
+        # Validate limit
+        try:
+            limit = min(int(limit), 5000)
+        except (ValueError, TypeError):
+            limit = 5000
+
+        # Crawl the category
+        result = crawl_category_articles(category_url, limit=limit)
+
+        if not result:
+            return jsonify({
+                "error": "Failed to crawl category. Please check the category URL."
+            }), 400
+
+        articles = result.get("articles", [])
+        imported = []
+        skipped = 0
+
+        # Get existing article links for this contest to avoid duplicates
+        existing_links = set(
+            s.article_link for s in Submission.query.filter_by(contest_id=contest_id).all()
         )
 
-        try:
-            submission.save()
-            imported.append(article_title)
-            existing_links.add(article_url)  # Prevent duplicates within this batch
-        except IntegrityError:
-            # Duplicate submission, skip
-            db.session.rollback()
-            skipped += 1
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            current_app.logger.error(f"Error creating submission for {article_title}: {str(e)}")
-            db.session.rollback()
-            skipped += 1
+        # Create submissions for each article
+        for article in articles:
+            article_url = article.get("url")
+            article_title = article.get("title")
 
-    return jsonify({
-        "message": f"Successfully imported {len(imported)} articles from category",
-        "total_imported": len(imported),
-        "skipped": skipped,
-        "category": result.get("category"),
-        "wiki_base": result.get("wiki_base"),
-        "articles": imported[:100],  # Return first 100 for preview
-    }), 200
+            # Skip if already submitted
+            if article_url in existing_links:
+                skipped += 1
+                continue
+
+            # Create pending submission
+            submission = Submission(
+                user_id=user.id,
+                contest_id=contest_id,
+                article_title=article_title,
+                article_link=article_url,
+                status="pending",
+            )
+
+            try:
+                submission.save()
+                imported.append(article_title)
+                existing_links.add(article_url)
+            except IntegrityError:
+                db.session.rollback()
+                skipped += 1
+            except Exception as e:
+                current_app.logger.error(f"Error creating submission for {article_title}: {str(e)}")
+                db.session.rollback()
+                skipped += 1
+
+        return jsonify({
+            "message": f"Successfully imported {len(imported)} articles from category",
+            "total_imported": len(imported),
+            "skipped": skipped,
+            "category": result.get("category"),
+            "wiki_base": result.get("wiki_base"),
+            "articles": imported[:100],
+        }), 200
+
+    except Exception as e:
+        current_app.logger.error(f"crawl_category_for_contest error: {str(e)}\n{traceback.format_exc()}")
+        return jsonify({"error": f"Internal server error: {str(e)}"}), 500

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1743,10 +1743,11 @@ def crawl_category_articles(
         headers = get_mediawiki_headers()
 
         # Build API params for category members
+        # cmtitle requires the full title with namespace prefix (e.g., "Category:Living_people")
         params = {
             "action": "query",
             "list": "categorymembers",
-            "cmtitle": category_name,
+            "cmtitle": f"Category:{category_name}",
             "cmtype": "page",  # Only get actual pages, not subcategories or files
             "cmlimit": "max",  # Max per request (usually 500)
             "cmnamespace": "0",  # Only mainspace articles
@@ -1812,6 +1813,9 @@ def crawl_category_articles(
             "wiki_base": wiki_base,
         }
 
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # pylint: disable=broad-exception-caught
         # If crawling fails, return None to indicate failure
+        # Log the error for debugging
+        import logging
+        logging.error(f"crawl_category_articles failed: {str(e)}")
         return None

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     "get_article_infobox_count",
     "get_article_incoming_links",
     "get_article_outgoing_links",
+    "crawl_category_articles",
 ]
 
 
@@ -1687,4 +1688,130 @@ def get_article_outgoing_links(article_url: str) -> Optional[int]:
     except Exception:  # pylint: disable=broad-exception-caught
         # If link counting fails, return None to indicate failure
         # This ensures submission process continues even if link counting fails
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Category Crawler Utilities
+# ---------------------------------------------------------------------------
+
+def crawl_category_articles(
+    category_url: str,
+    limit: int = 5000,
+    mw_uri: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """
+    Crawl articles from a Wikipedia category using the MediaWiki API.
+
+    Uses the `list=categorymembers` API to fetch all pages in a category,
+    handling pagination via `cmcontinue` tokens.
+
+    Args:
+        category_url: Full URL to a Wikipedia category page.
+            Examples:
+            - https://en.wikipedia.org/wiki/Category:Living_people
+            - https://es.wikipedia.org/wiki/Categoría:Wikipedia
+        limit: Maximum number of articles to fetch (default: 5000, max: 5000).
+        mw_uri: Optional MediaWiki API base URI. If not provided, extracted from category_url.
+
+    Returns:
+        Dictionary with:
+            - "articles": List of dicts with "title" and "url" keys
+            - "total": Total number of articles fetched
+            - "category": Category name extracted from URL
+            - "wiki_base": Wiki base URL (e.g., "https://en.wikipedia.org")
+        Or None if an error occurs.
+    """
+    try:
+        # Enforce maximum limit
+        limit = min(limit, 5000)
+
+        # Extract category name from URL
+        category_name = extract_category_name_from_url(category_url)
+        if not category_name:
+            return None
+
+        # Parse wiki base URL from category URL
+        parsed = urlparse(category_url)
+        wiki_base = f"{parsed.scheme}://{parsed.netloc}"
+        api_url = f"{wiki_base}/w/api.php"
+
+        # Determine MediaWiki URI
+        if mw_uri is None:
+            mw_uri = api_url
+
+        headers = get_mediawiki_headers()
+
+        # Build API params for category members
+        params = {
+            "action": "query",
+            "list": "categorymembers",
+            "cmtitle": category_name,
+            "cmtype": "page",  # Only get actual pages, not subcategories or files
+            "cmlimit": "max",  # Max per request (usually 500)
+            "cmnamespace": "0",  # Only mainspace articles
+            "format": "json",
+        }
+
+        articles = []
+        continue_token = None
+
+        while len(articles) < limit:
+            # Add continue token if we have one
+            if continue_token:
+                params["cmcontinue"] = continue_token
+
+            response = requests.get(
+                mw_uri,
+                params=params,
+                headers=headers,
+                timeout=MEDIAWIKI_API_TIMEOUT
+            )
+
+            if response.status_code != 200:
+                break
+
+            data = response.json()
+
+            if "error" in data:
+                break
+
+            # Extract category members
+            members = data.get("query", {}).get("categorymembers", [])
+
+            for member in members:
+                if len(articles) >= limit:
+                    break
+
+                title = member.get("title")
+                page_id = member.get("pageid")
+
+                if title:
+                    # Build article URL
+                    # Use /wiki/ format for cleaner URLs
+                    encoded_title = title.replace(" ", "_")
+                    article_url = f"{wiki_base}/wiki/{encoded_title}"
+
+                    articles.append({
+                        "title": title,
+                        "url": article_url,
+                        "page_id": page_id,
+                    })
+
+            # Check for continuation
+            continue_data = data.get("continue")
+            if continue_data and "cmcontinue" in continue_data:
+                continue_token = continue_data["cmcontinue"]
+            else:
+                break
+
+        return {
+            "articles": articles,
+            "total": len(articles),
+            "category": category_name,
+            "wiki_base": wiki_base,
+        }
+
+    except Exception:  # pylint: disable=broad-exception-caught
+        # If crawling fails, return None to indicate failure
         return None

--- a/frontend/src/views/ContestView.vue
+++ b/frontend/src/views/ContestView.vue
@@ -527,6 +527,61 @@ aria-labelledby="outreach-tab">
                   <i class="fas fa-info-circle"></i>
                   <span>Articles are automatically scored based on metrics and eligibility criteria</span>
                 </div>
+
+                <!-- Category Crawler Section -->
+                <div class="crawler-section" v-if="canEdit">
+                  <h6 class="section-title"><i class="fas fa-download me-2"></i>Import Articles from Category</h6>
+                  <div class="crawler-form">
+                    <input
+                      type="text"
+                      v-model="categoryUrl"
+                      placeholder="Enter Wikipedia category URL (e.g., https://en.wikipedia.org/wiki/Category:Test_articles)"
+                      class="form-control crawler-input"
+                    />
+                    <input
+                      type="number"
+                      v-model.number="crawlLimit"
+                      placeholder="Limit"
+                      min="1"
+                      max="5000"
+                      class="form-control crawler-limit"
+                    />
+                    <button
+                      class="btn btn-primary crawler-btn"
+                      @click="crawlCategory"
+                      :disabled="crawling || !categoryUrl"
+                    >
+                      <span v-if="crawling">
+                        <i class="fas fa-spinner fa-spin me-1"></i> Importing...
+                      </span>
+                      <span v-else>
+                        <i class="fas fa-cloud-download-alt me-1"></i> Import Articles
+                      </span>
+                    </button>
+                  </div>
+                  <div v-if="crawlResult" class="crawl-result">
+                    <div class="alert alert-success" v-if="crawlResult.total_imported > 0">
+                      <i class="fas fa-check-circle me-2"></i>
+                      {{ crawlResult.message }}
+                      <br />
+                      <small>Category: {{ crawlResult.category }}</small>
+                      <br />
+                      <small>Skipped (duplicates): {{ crawlResult.skipped }}</small>
+                    </div>
+                    <div class="alert alert-warning" v-else-if="crawlResult.skipped > 0">
+                      <i class="fas fa-exclamation-triangle me-2"></i>
+                      All {{ crawlResult.skipped }} articles were duplicates
+                    </div>
+                    <div class="alert alert-info" v-else>
+                      <i class="fas fa-info-circle me-2"></i>
+                      No articles found in category
+                    </div>
+                  </div>
+                  <div v-if="crawlError" class="alert alert-danger">
+                    <i class="fas fa-exclamation-circle me-2"></i>
+                    {{ crawlError }}
+                  </div>
+                </div>
               </div>
 
               <!-- Multi-Parameter Scoring Display -->
@@ -1744,6 +1799,51 @@ export default {
       }
     }
 
+    // Category crawler state
+    const categoryUrl = ref('')
+    const crawlLimit = ref(100)
+    const crawling = ref(false)
+    const crawlResult = ref(null)
+    const crawlError = ref(null)
+
+    // Crawl category and import articles
+    const crawlCategory = async () => {
+      if (!categoryUrl.value) return
+
+      crawling.value = true
+      crawlResult.value = null
+      crawlError.value = null
+
+      try {
+        const response = await fetch(`/api/contest/${contest.value.id}/crawl-category`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          credentials: 'include',
+          body: JSON.stringify({
+            category_url: categoryUrl.value,
+            limit: crawlLimit.value || 100
+          })
+        })
+
+        const data = await response.json()
+
+        if (!response.ok) {
+          throw new Error(data.error || 'Failed to crawl category')
+        }
+
+        crawlResult.value = data
+
+        // Refresh submissions list to show new imports
+        await fetchSubmissions()
+      } catch (err) {
+        crawlError.value = err.message || 'An error occurred while crawling the category'
+      } finally {
+        crawling.value = false
+      }
+    }
+
     // Track current submission for preview modal
     const currentSubmissionId = ref(null)
 
@@ -2771,7 +2871,14 @@ export default {
       reviewedSubmissionsCount,
       contestScoringMode,
       automatedSettings,
-      loadDefaultAutomatedSettings
+      loadDefaultAutomatedSettings,
+      // Category crawler
+      categoryUrl,
+      crawlLimit,
+      crawling,
+      crawlResult,
+      crawlError,
+      crawlCategory
     }
   }
 }
@@ -3402,6 +3509,83 @@ export default {
   font-weight: 700;
   font-size: 1.25rem;
   color: var(--wiki-primary);
+}
+
+/* Category Crawler Styles */
+.crawler-section {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: #f8fafc;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+}
+
+[data-theme="dark"] .crawler-section {
+  background: #1a1a2e;
+  border-color: #334155;
+}
+
+.crawler-section .section-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--wiki-text);
+  margin-bottom: 0.75rem;
+}
+
+.crawler-form {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.crawler-input {
+  flex: 1;
+  min-width: 280px;
+  padding: 0.625rem 0.875rem;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  font-size: 0.875rem;
+}
+
+[data-theme="dark"] .crawler-input {
+  background: #1f1f1f;
+  border-color: #404040;
+  color: #e5e7eb;
+}
+
+.crawler-limit {
+  width: 100px;
+  padding: 0.625rem 0.875rem;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  font-size: 0.875rem;
+}
+
+[data-theme="dark"] .crawler-limit {
+  background: #1f1f1f;
+  border-color: #404040;
+  color: #e5e7eb;
+}
+
+.crawler-btn {
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.crawler-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.crawl-result {
+  margin-top: 1rem;
+}
+
+.crawl-result .alert {
+  margin-bottom: 0;
+  font-size: 0.875rem;
 }
 
 /* --------------------------------------------------------------------------

--- a/frontend/src/views/ContestView.vue
+++ b/frontend/src/views/ContestView.vue
@@ -393,6 +393,73 @@ title="Delete Submission"
         </div>
       </div>
 
+      <!-- Category Crawler Section (for Automated Scoring Contests) -->
+      <!-- DEBUG INFO -->
+      <!--<div class="alert alert-secondary mb-2">
+        <small>
+          <strong>Debug:</strong> automated_settings.enabled = {{ contest.automated_settings?.enabled }}, 
+          categories = {{ contest.categories }}
+        </small>
+      </div>-->
+      <div v-if="contest.automated_settings?.enabled === true && contest.categories && contest.categories.length > 0 && canImportArticles" class="card mb-4">
+        <div class="card-header">
+          <h5 class="mb-0"><i class="fas fa-download me-2"></i>Import Articles from Category</h5>
+        </div>
+        <div class="card-body">
+          <p class="text-muted mb-3">Import articles from the contest's configured categories as pending submissions.</p>
+          
+          <div class="crawler-form">
+            <select v-model="selectedCategory" class="form-select crawler-select">
+              <option value="">Select a category...</option>
+              <option v-for="cat in contest.categories" :key="cat" :value="cat">{{ cat }}</option>
+            </select>
+            <input
+              type="number"
+              v-model.number="crawlLimit"
+              placeholder="Limit"
+              min="1"
+              max="5000"
+              class="form-control crawler-limit"
+            />
+            <button
+              class="btn btn-primary crawler-btn"
+              @click="crawlCategory"
+              :disabled="crawling || !selectedCategory"
+            >
+              <span v-if="crawling">
+                <i class="fas fa-spinner fa-spin me-1"></i> Importing...
+              </span>
+              <span v-else>
+                <i class="fas fa-cloud-download-alt me-1"></i> Import Articles
+              </span>
+            </button>
+          </div>
+          
+          <div v-if="crawlResult" class="crawl-result mt-3">
+            <div class="alert alert-success" v-if="crawlResult.total_imported > 0">
+              <i class="fas fa-check-circle me-2"></i>
+              {{ crawlResult.message }}
+              <br />
+              <small>Category: {{ crawlResult.category }}</small>
+              <br />
+              <small>Skipped (duplicates): {{ crawlResult.skipped }}</small>
+            </div>
+            <div class="alert alert-warning" v-else-if="crawlResult.skipped > 0">
+              <i class="fas fa-exclamation-triangle me-2"></i>
+              All {{ crawlResult.skipped }} articles were duplicates
+            </div>
+            <div class="alert alert-info" v-else>
+              <i class="fas fa-info-circle me-2"></i>
+              No articles found in category
+            </div>
+          </div>
+          <div v-if="crawlError" class="alert alert-danger mt-3">
+            <i class="fas fa-exclamation-circle me-2"></i>
+            {{ crawlError }}
+          </div>
+        </div>
+      </div>
+
       <!-- Bottom Action Row -->
       <div class="d-flex justify-content-between align-items-center gap-2 mb-4">
         <!-- Debug warning for auth issues -->
@@ -526,61 +593,6 @@ aria-labelledby="outreach-tab">
                 <div class="info-note">
                   <i class="fas fa-info-circle"></i>
                   <span>Articles are automatically scored based on metrics and eligibility criteria</span>
-                </div>
-
-                <!-- Category Crawler Section -->
-                <div class="crawler-section" v-if="canEdit">
-                  <h6 class="section-title"><i class="fas fa-download me-2"></i>Import Articles from Category</h6>
-                  <div class="crawler-form">
-                    <input
-                      type="text"
-                      v-model="categoryUrl"
-                      placeholder="Enter Wikipedia category URL (e.g., https://en.wikipedia.org/wiki/Category:Test_articles)"
-                      class="form-control crawler-input"
-                    />
-                    <input
-                      type="number"
-                      v-model.number="crawlLimit"
-                      placeholder="Limit"
-                      min="1"
-                      max="5000"
-                      class="form-control crawler-limit"
-                    />
-                    <button
-                      class="btn btn-primary crawler-btn"
-                      @click="crawlCategory"
-                      :disabled="crawling || !categoryUrl"
-                    >
-                      <span v-if="crawling">
-                        <i class="fas fa-spinner fa-spin me-1"></i> Importing...
-                      </span>
-                      <span v-else>
-                        <i class="fas fa-cloud-download-alt me-1"></i> Import Articles
-                      </span>
-                    </button>
-                  </div>
-                  <div v-if="crawlResult" class="crawl-result">
-                    <div class="alert alert-success" v-if="crawlResult.total_imported > 0">
-                      <i class="fas fa-check-circle me-2"></i>
-                      {{ crawlResult.message }}
-                      <br />
-                      <small>Category: {{ crawlResult.category }}</small>
-                      <br />
-                      <small>Skipped (duplicates): {{ crawlResult.skipped }}</small>
-                    </div>
-                    <div class="alert alert-warning" v-else-if="crawlResult.skipped > 0">
-                      <i class="fas fa-exclamation-triangle me-2"></i>
-                      All {{ crawlResult.skipped }} articles were duplicates
-                    </div>
-                    <div class="alert alert-info" v-else>
-                      <i class="fas fa-info-circle me-2"></i>
-                      No articles found in category
-                    </div>
-                  </div>
-                  <div v-if="crawlError" class="alert alert-danger">
-                    <i class="fas fa-exclamation-circle me-2"></i>
-                    {{ crawlError }}
-                  </div>
                 </div>
               </div>
 
@@ -852,6 +864,73 @@ title="Delete Submission"
                   </tr>
                 </tbody>
               </table>
+            </div>
+          </div>
+        </div>
+
+        <!-- Category Crawler Section (for Automated Scoring Contests) -->
+        <!-- DEBUG INFO -->
+        <!-- <div class="alert alert-secondary mb-2">
+          <small>
+            <strong>Debug:</strong> automated_settings.enabled = {{ contest.automated_settings?.enabled }}, 
+            categories = {{ contest.categories }}
+          </small>
+        </div> -->
+        <div v-if="contest.automated_settings?.enabled === true && contest.categories && contest.categories.length > 0 && canImportArticles" class="card mb-4">
+          <div class="card-header">
+            <h5 class="mb-0"><i class="fas fa-download me-2"></i>Import Articles from Category</h5>
+          </div>
+          <div class="card-body">
+            <p class="text-muted mb-3">Import articles from the contest's configured categories as pending submissions.</p>
+            
+            <div class="crawler-form">
+              <select v-model="selectedCategory" class="form-select crawler-select">
+                <option value="">Select a category...</option>
+                <option v-for="cat in contest.categories" :key="cat" :value="cat">{{ cat }}</option>
+              </select>
+              <input
+                type="number"
+                v-model.number="crawlLimit"
+                placeholder="Limit"
+                min="1"
+                max="5000"
+                class="form-control crawler-limit"
+              />
+              <button
+                class="btn btn-primary crawler-btn"
+                @click="crawlCategory"
+                :disabled="crawling || !selectedCategory"
+              >
+                <span v-if="crawling">
+                  <i class="fas fa-spinner fa-spin me-1"></i> Importing...
+                </span>
+                <span v-else>
+                  <i class="fas fa-cloud-download-alt me-1"></i> Import Articles
+                </span>
+              </button>
+            </div>
+            
+            <div v-if="crawlResult" class="crawl-result mt-3">
+              <div class="alert alert-success" v-if="crawlResult.total_imported > 0">
+                <i class="fas fa-check-circle me-2"></i>
+                {{ crawlResult.message }}
+                <br />
+                <small>Category: {{ crawlResult.category }}</small>
+                <br />
+                <small>Skipped (duplicates): {{ crawlResult.skipped }}</small>
+              </div>
+              <div class="alert alert-warning" v-else-if="crawlResult.skipped > 0">
+                <i class="fas fa-exclamation-triangle me-2"></i>
+                All {{ crawlResult.skipped }} articles were duplicates
+              </div>
+              <div class="alert alert-info" v-else>
+                <i class="fas fa-info-circle me-2"></i>
+                No articles found in category
+              </div>
+            </div>
+            <div v-if="crawlError" class="alert alert-danger mt-3">
+              <i class="fas fa-exclamation-circle me-2"></i>
+              {{ crawlError }}
             </div>
           </div>
         </div>
@@ -1674,6 +1753,14 @@ import SubmitArticleModal from '../components/SubmitArticleModal.vue'
 import ArticlePreviewModal from '../components/ArticlePreviewModal.vue'
 import OutreachDashboardTab from '../components/OutreachDashboardTab.vue'
 
+// Helper function to get CSRF token from cookies
+function getCookie(name) {
+  return document.cookie
+    .split('; ')
+    .find(row => row.startsWith(name + '='))
+    ?.split('=')[1]
+}
+
 export default {
   name: 'ContestView',
   components: {
@@ -1800,7 +1887,7 @@ export default {
     }
 
     // Category crawler state
-    const categoryUrl = ref('')
+    const selectedCategory = ref('')
     const crawlLimit = ref(100)
     const crawling = ref(false)
     const crawlResult = ref(null)
@@ -1808,21 +1895,23 @@ export default {
 
     // Crawl category and import articles
     const crawlCategory = async () => {
-      if (!categoryUrl.value) return
+      if (!selectedCategory.value) return
 
       crawling.value = true
       crawlResult.value = null
       crawlError.value = null
 
       try {
+        const csrfToken = getCookie('csrf_access_token')
         const response = await fetch(`/api/contest/${contest.value.id}/crawl-category`, {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': csrfToken || ''
           },
           credentials: 'include',
           body: JSON.stringify({
-            category_url: categoryUrl.value,
+            category_url: selectedCategory.value,
             limit: crawlLimit.value || 100
           })
         })
@@ -1888,6 +1977,29 @@ export default {
       // Jury members can view submissions
       if (contestData.jury_members && Array.isArray(contestData.jury_members)) {
         const juryUsernames = contestData.jury_members.map(j => (j || '').trim().toLowerCase())
+        return juryUsernames.includes(username)
+      }
+
+      return false
+    })
+
+    // Determine if user can import articles (jury member or superadmin only)
+    const canImportArticles = computed(() => {
+      if (!isAuthenticated.value || !contest.value || !currentUser.value) {
+        return false
+      }
+
+      const username = (currentUser.value.username || '').trim().toLowerCase()
+      const role = (currentUser.value.role || '').trim().toLowerCase()
+
+      // Superadmin can always import
+      if (role === 'superadmin') {
+        return true
+      }
+
+      // Jury members can import
+      if (contest.value.jury_members && Array.isArray(contest.value.jury_members)) {
+        const juryUsernames = contest.value.jury_members.map(j => (j || '').trim().toLowerCase())
         return juryUsernames.includes(username)
       }
 
@@ -2873,12 +2985,12 @@ export default {
       automatedSettings,
       loadDefaultAutomatedSettings,
       // Category crawler
-      categoryUrl,
+      selectedCategory,
       crawlLimit,
       crawling,
       crawlResult,
       crawlError,
-      crawlCategory
+      canImportArticles,
     }
   }
 }
@@ -3536,6 +3648,21 @@ export default {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.crawler-select {
+  flex: 1;
+  min-width: 280px;
+  padding: 0.625rem 0.875rem;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  font-size: 0.875rem;
+}
+
+[data-theme="dark"] .crawler-select {
+  background: #1f1f1f;
+  border-color: #404040;
+  color: #e5e7eb;
 }
 
 .crawler-input {


### PR DESCRIPTION
Allow importing articles from Wikipedia categories as pending submissions.
- Category selector with configurable import limit (up to 5000 articles)
- Automatic duplicate detection to skip already-submitted articles
- Import summary showing total imported and skipped counts
- Available only for automated scoring contests with configured categories
- Restricted to jury members and superadmins
