### PR TITLE
WikiEval Tool / WikiContest violates Toolforge Privacy Policy

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,26 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WikiContest - Contest Management Platform</title>
-    
-    <!-- Google Fonts - Inter font family for modern typography -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    
-    <!-- Bootstrap CSS for responsive layout and components -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    
-    <!-- Font Awesome for icons throughout the application -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <title>WikiEval - Contest Management Platform</title>
+
+    <!-- Inter font - served via Toolforge approved CDN -->
+    <link href="https://tools-static.wmflabs.org/fontcdn/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+    <!-- Bootstrap CSS - served via Toolforge approved CDN -->
+    <link href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Font Awesome - served via Toolforge approved CDN -->
+    <link href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>
 <body>
     <!-- Vue.js app will mount here -->
     <div id="app"></div>
-    
-    <!-- Bootstrap JS for interactive components (modals, dropdowns, etc.) -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-    
+
+    <!-- Bootstrap JS - served via Toolforge approved CDN -->
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js"></script>
+
     <!-- Vue.js application entry point -->
     <script type="module" src="/src/main.js"></script>
 </body>


### PR DESCRIPTION
Replace banned external CDNs with Toolforge-approved tools-static.wmflabs.org endpoints.

Changes:
- Google Fonts → tools-static.wmflabs.org/fontcdn
- Bootstrap CSS/JS (cdn.jsdelivr.net) → tools-static.wmflabs.org/cdnjs
- Font Awesome (cdnjs.cloudflare.com) → tools-static.wmflabs.org/cdnjs

Fixes Toolforge Privacy Policy violation reported at:
https://wikitech.wikimedia.org/wiki/Help:Toolforge/Web#Load_external_assets_using_our_CDN_services
Phabricator Ticket: https://phabricator.wikimedia.org/T427744